### PR TITLE
Ensure Spotless checks are run in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,7 +206,7 @@ jobs:
       - run:
           name: Spotless
           command: ./gradlew spotlessCheck
-     - run:
+      - run:
           name: Build and test
           command: ./gradlew test
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,6 +204,9 @@ jobs:
           command: docker-compose up
       - run: sleep 30
       - run:
+          name: Spotless
+          command: ./gradlew spotlessCheck
+     - run:
           name: Build and test
           command: ./gradlew test
       - run:

--- a/messaging/txroot-transfer/src/test/java/net/consensys/gpact/txroot/TxRootAddTest.java
+++ b/messaging/txroot-transfer/src/test/java/net/consensys/gpact/txroot/TxRootAddTest.java
@@ -232,9 +232,9 @@ public class TxRootAddTest extends AbstractWeb3Test {
     }
 
     while (true) {
-      
+
       BigInteger id = BigInteger.TWO;
-  
+
       //    CompletableFuture<TransactionReceipt>[] transactionReceiptCompletableFutures =
       //        (CompletableFuture<TransactionReceipt>[]) new Object[numTransactionsPerBlock];
       CompletableFuture<?>[] transactionReceiptCompletableFutures =
@@ -246,7 +246,7 @@ public class TxRootAddTest extends AbstractWeb3Test {
       CompletableFuture<Void> combinedFuture =
           CompletableFuture.allOf(transactionReceiptCompletableFutures);
       combinedFuture.get();
-  
+
       Set<String> headers = new HashSet<String>();
       for (int i = 0; i < numTransactionsPerBlock; i++) {
         receipts[i] = (TransactionReceipt) transactionReceiptCompletableFutures[i].get();


### PR DESCRIPTION
This PR ensures that Spotless checks are run on CircleCI, and addresses a formatting issue introduced through PR #44 