### PR TITLE
Fix replay prevention

### DIFF
--- a/functioncall/gpact/src/main/solidity/CrosschainControl.sol
+++ b/functioncall/gpact/src/main/solidity/CrosschainControl.sol
@@ -192,7 +192,7 @@ contract CrosschainControl is
                 segmentTransactionExecuted[mapKey] == false,
                 "Segment transaction already executed"
             );
-            segmentTransactionExecuted[mapKey] == true;
+            segmentTransactionExecuted[mapKey] = true;
         }
         bytes32 hashOfCallGraph = keccak256(callGraph);
 


### PR DESCRIPTION
A comparison is done rather than assignment.
This fixes that, so that segmentTransactionExecuted[mapKey] == true after the first execution