### PR TITLE
Upgrade log4j

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ allprojects {
 }
 
 ext {
-    log4JVersion = '2.16.0'
+    log4JVersion = '2.17.1'
     okHttpVersion = '4.9.1'
     jacksonVersion = '2.13.0'
     rxJavaVersion = '2.2.21'


### PR DESCRIPTION
This PR upgrades log4j to version `2.17.1`, which addresses the vulnerabilities [CVE-2021-44832](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44832) and [CVE-2021-45105](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105)