### PR TITLE
Add handler for removed events

### DIFF
--- a/messaging/relayer/internal/msgobserver/eth/observer/event_handler.go
+++ b/messaging/relayer/internal/msgobserver/eth/observer/event_handler.go
@@ -17,6 +17,7 @@ package observer
 
 import (
 	"fmt"
+	"github.com/consensys/gpact/messaging/relayer/internal/logging"
 )
 
 type EventHandler interface {
@@ -43,4 +44,18 @@ func (h *SimpleEventHandler) Handle(event interface{}) error {
 
 func NewSimpleEventHandler(transformer EventTransformer, sender MessageHandler) *SimpleEventHandler {
 	return &SimpleEventHandler{EventTransformer: transformer, MessageHandler: sender}
+}
+
+// LogEventHandler logs the details of a given event at an `Info` level
+type LogEventHandler struct {
+	LogMessagePrefix string
+}
+
+func (h *LogEventHandler) Handle(event interface{}) error {
+	logging.Info("%s: %v", h.LogMessagePrefix, event)
+	return nil
+}
+
+func NewLogEventHandler(logPrefix string) *LogEventHandler {
+	return &LogEventHandler{logPrefix}
 }

--- a/messaging/relayer/internal/msgobserver/eth/observer/event_watcher_test.go
+++ b/messaging/relayer/internal/msgobserver/eth/observer/event_watcher_test.go
@@ -43,7 +43,8 @@ func TestSFCCrossCallRealtimeEventWatcher(t *testing.T) {
 	handler := new(MockEventHandler)
 	handler.On("Handle", mock.AnythingOfType("*functioncall.SfcCrossCall")).Once().Return(nil)
 
-	watcher := NewSFCCrossCallRealtimeEventWatcher(auth.Context, handler, contract, make(chan bool))
+	watcher, err := NewSFCCrossCallRealtimeEventWatcher(auth.Context, handler, handler, contract, make(chan bool))
+	assert.Nil(t, err, "failed to create a realtime event watcher")
 	go watcher.Watch()
 
 	makeCrossContractCallTx(t, contract, auth)
@@ -52,8 +53,43 @@ func TestSFCCrossCallRealtimeEventWatcher(t *testing.T) {
 	handler.AssertExpectations(t)
 }
 
+func TestSFCCrossCallRealtimeEventWatcher_RemovedEvent(t *testing.T) {
+	simBackend, auth := simulatedBackend(t)
+	contract := deployContract(t, simBackend, auth)
+
+	handler := new(MockEventHandler)
+	handler.On("Handle", mock.AnythingOfType("*functioncall.SfcCrossCall")).Once().Return(nil)
+
+	removedHandler := new(MockEventHandler)
+	removedHandler.On("Handle", mock.AnythingOfType("*functioncall.SfcCrossCall")).Once().Return(nil)
+
+	watcher, err := NewSFCCrossCallRealtimeEventWatcher(auth.Context, handler, removedHandler, contract, make(chan bool))
+	assert.Nil(t, err, "failed to create a realtime event watcher")
+	go watcher.Watch()
+
+	b1 := simBackend.Blockchain().CurrentBlock().Hash()
+
+	makeCrossContractCallTx(t, contract, auth)
+	commit(simBackend)
+
+	err = simBackend.Fork(auth.Context, b1)
+	assert.Nil(t, err, "could not simulate forking blockchain")
+	mineConfirmingBlocks(1, simBackend)
+	commitAndSleep(simBackend)
+
+	handler.AssertExpectations(t)
+	removedHandler.AssertExpectations(t)
+}
+
 func TestSFCCrossCallFinalisedEventWatcher_FailsIfConfirmationTooLow(t *testing.T) {
-	_, err := NewSFCCrossCallFinalisedEventWatcher(nil, 0, nil, nil, 0,
+	handler := new(MockEventHandler)
+	_, err := NewSFCCrossCallFinalisedEventWatcher(nil, 0, handler, nil, 0,
+		nil, make(chan bool))
+	assert.NotNil(t, err)
+}
+
+func TestSFCCrossCallFinalisedEventWatcher_FailsIfEventHandlerNil(t *testing.T) {
+	_, err := NewSFCCrossCallFinalisedEventWatcher(nil, 2, nil, nil, 0,
 		nil, make(chan bool))
 	assert.NotNil(t, err)
 }
@@ -139,12 +175,12 @@ func TestSFCCrossCallFinalisedEventWatcher_Reorg(t *testing.T) {
 	assert.Nil(t, e)
 	go watcher.Watch()
 
-	makeCrossContractCallTx(t, contract, auth)
 	b1 := simBackend.Blockchain().CurrentBlock().Hash()
+	makeCrossContractCallTx(t, contract, auth)
 	commit(simBackend)
+
 	err := simBackend.Fork(auth.Context, b1)
 	assert.Nil(t, err, "could not simulate forking blockchain")
-
 	mineConfirmingBlocks(2, simBackend)
 	time.Sleep(2 * time.Second)
 
@@ -170,6 +206,6 @@ func commit(backend *backends.SimulatedBackend) {
 }
 
 func commitAndSleep(backend *backends.SimulatedBackend) {
-	backend.Commit()
+	commit(backend)
 	time.Sleep(2 * time.Second)
 }

--- a/messaging/relayer/internal/msgobserver/eth/observer/event_watcher_test.go
+++ b/messaging/relayer/internal/msgobserver/eth/observer/event_watcher_test.go
@@ -72,6 +72,8 @@ func TestSFCCrossCallRealtimeEventWatcher_RemovedEvent(t *testing.T) {
 	makeCrossContractCallTx(t, contract, auth)
 	commit(simBackend)
 
+	// create a fork of the chain that excludes the event. turn this chain into the longer chain.
+	// this will cause the event log to be re-sent with a 'removed' flag set
 	err = simBackend.Fork(auth.Context, b1)
 	assert.Nil(t, err, "could not simulate forking blockchain")
 	mineConfirmingBlocks(1, simBackend)

--- a/messaging/relayer/internal/msgobserver/eth/observer/message_observer.go
+++ b/messaging/relayer/internal/msgobserver/eth/observer/message_observer.go
@@ -34,8 +34,11 @@ func NewSFCBridgeObserver(source string, sourceAddr string, contract *functionca
 	eventTransformer := NewSFCEventTransformer(source, sourceAddr)
 	messageHandler := NewMessageEnqueueHandler(mq)
 	eventHandler := NewSimpleEventHandler(eventTransformer, messageHandler)
-	eventWatcher := NewSFCCrossCallRealtimeEventWatcher(context.Background(), eventHandler, contract, end)
-
+	removedEvHandler := NewLogEventHandler("removed event")
+	eventWatcher, err := NewSFCCrossCallRealtimeEventWatcher(context.Background(), eventHandler, removedEvHandler, contract, end)
+	if err != nil {
+		return nil, err
+	}
 	return &SFCBridgeObserver{EventWatcher: eventWatcher, EventHandler: eventHandler, SourceNetwork: source}, nil
 }
 


### PR DESCRIPTION
At present, the real-time event watcher does not specifically handle events affected by reorgs. This leads to the same event potentially being sent multiple times to the Relayer core. However, one of the [guarantees that the watcher should offer downstream components is that events are unique](https://github.com/ConsenSys/gpact/blob/main/doc/message-observer.md#event-watcher). To this end, this PR introduces a way of discerning removed events in the watcher and using a separate event handler to deal with them.