### PR TITLE
Improve resilience of the Message Observer to transient failures

### DIFF
--- a/services/relayer/go.mod
+++ b/services/relayer/go.mod
@@ -3,6 +3,7 @@ module github.com/consensys/gpact/messaging/relayer
 go 1.17
 
 require (
+	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c
 	github.com/ethereum/go-ethereum v1.10.13
 	github.com/ipfs/go-datastore v0.5.1

--- a/services/relayer/go.sum
+++ b/services/relayer/go.sum
@@ -52,6 +52,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
+github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
+github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-sdk-go-v2 v1.2.0/go.mod h1:zEQs02YRBw1DjK0PoJv3ygDYOFTre1ejlJWl8FwAuQo=
 github.com/aws/aws-sdk-go-v2/config v1.1.1/go.mod h1:0XsVy9lBI/BCXm+2Tuvt39YmdHwS5unDQmxZOYe8F5Y=
 github.com/aws/aws-sdk-go-v2/credentials v1.1.1/go.mod h1:mM2iIjwl7LULWtS6JCACyInboHirisUUdkBPoTHMOUo=

--- a/services/relayer/internal/mqserver/mqserver.go
+++ b/services/relayer/internal/mqserver/mqserver.go
@@ -23,7 +23,7 @@ import (
 
 type MessageQueue interface {
 	// Request sends a message to the message queue.
-	Request(version string, msgType string, msg messages.Message)
+	Request(version string, msgType string, msg messages.Message) error
 
 	// Start starts the message handling routine.
 	Start() error
@@ -145,23 +145,17 @@ func (s *MQServer) Start() error {
 }
 
 // Request sends a message to the message queue.
-func (s *MQServer) Request(version string, msgType string, msg messages.Message) {
-	// Use a routine to push the message.
-	go func() {
-		err := s.chanOut.Publish(
-			"",
-			s.queue.Name,
-			false,
-			false,
-			amqp.Publishing{
-				Headers: amqp.Table{"version": version},
-				Type:    msgType,
-				Body:    msg.ToBytes(),
-			})
-		if err != nil {
-			logging.Info(err.Error())
-		}
-	}()
+func (s *MQServer) Request(version string, msgType string, msg messages.Message) error {
+	return s.chanOut.Publish(
+		"",
+		s.queue.Name,
+		false,
+		false,
+		amqp.Publishing{
+			Headers: amqp.Table{"version": version},
+			Type:    msgType,
+			Body:    msg.ToBytes(),
+		})
 }
 
 // handleIncomingMsgRoutine is a routine for handling incoming messages.

--- a/services/relayer/internal/msgobserver/eth/observer/event_handler.go
+++ b/services/relayer/internal/msgobserver/eth/observer/event_handler.go
@@ -16,15 +16,14 @@ package observer
  */
 
 import (
-	"fmt"
 	"github.com/consensys/gpact/messaging/relayer/internal/logging"
 )
 
 type EventHandler interface {
-	Handle(event interface{}) error
+	Handle(event interface{})
 }
 
-// SimpleEventHandler first transforms an event to a relayer message then passes it to a handler to process
+// SimpleEventHandler first transforms an event to a relayer message then passes it to a message handler to process
 type SimpleEventHandler struct {
 	// EventTransformer transforms a given event to a relayer message (v1.Message)
 	EventTransformer EventTransformer
@@ -33,13 +32,13 @@ type SimpleEventHandler struct {
 }
 
 // Handle transforms the provided event to a message then forwards it to a message handler to process.
-func (h *SimpleEventHandler) Handle(event interface{}) error {
+func (h *SimpleEventHandler) Handle(event interface{}) {
 	message, err := h.EventTransformer.ToMessage(event)
 	if err != nil {
-		return fmt.Errorf("error transforming event. %v", err)
-
+		logging.Error("error transforming event: %v, error: %v", event, err)
+		return
 	}
-	return h.MessageHandler.Handle(message)
+	h.MessageHandler.Handle(message)
 }
 
 func NewSimpleEventHandler(transformer EventTransformer, sender MessageHandler) *SimpleEventHandler {
@@ -51,9 +50,8 @@ type LogEventHandler struct {
 	LogMessagePrefix string
 }
 
-func (h *LogEventHandler) Handle(event interface{}) error {
+func (h *LogEventHandler) Handle(event interface{}) {
 	logging.Info("%s: %v", h.LogMessagePrefix, event)
-	return nil
 }
 
 func NewLogEventHandler(logPrefix string) *LogEventHandler {

--- a/services/relayer/internal/msgobserver/eth/observer/event_watcher_test.go
+++ b/services/relayer/internal/msgobserver/eth/observer/event_watcher_test.go
@@ -20,9 +20,13 @@ import (
 	"github.com/consensys/gpact/messaging/relayer/internal/logging"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
+	"github.com/ipfs/go-datastore"
+	badger "github.com/ipfs/go-ds-badger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"io/ioutil"
 	"math/big"
+	"os"
 	"testing"
 	"time"
 )
@@ -35,6 +39,22 @@ func (m *MockEventHandler) Handle(event interface{}) {
 	m.Called(event)
 }
 
+func newDS(t *testing.T) (*badger.Datastore, func()) {
+	path, err := ioutil.TempDir(os.TempDir(), "testing_badger_")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := badger.NewDatastore(path, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d, func() {
+		d.Close()
+		os.RemoveAll(path)
+	}
+}
+
 func TestSFCCrossCallRealtimeEventWatcher(t *testing.T) {
 	simBackend, auth := simulatedBackend(t)
 	contract := deployContract(t, simBackend, auth)
@@ -42,9 +62,14 @@ func TestSFCCrossCallRealtimeEventWatcher(t *testing.T) {
 	handler := new(MockEventHandler)
 	handler.On("Handle", mock.AnythingOfType("*functioncall.SfcCrossCall")).Once().Return(nil)
 
-	watcher, err := NewSFCCrossCallRealtimeEventWatcher(auth.Context, handler, handler, contract, make(chan bool))
+	opts := EventWatcherOpts{
+		Context:      auth.Context,
+		EventHandler: handler,
+	}
+	watcher, err := NewSFCCrossCallRealtimeEventWatcher(opts, handler, contract, make(chan bool))
 	assert.Nil(t, err, "failed to create a realtime event watcher")
 	go watcher.Watch()
+	defer watcher.StopWatcher()
 
 	makeCrossContractCallTx(t, contract, auth)
 
@@ -62,9 +87,14 @@ func TestSFCCrossCallRealtimeEventWatcher_RemovedEvent(t *testing.T) {
 	removedHandler := new(MockEventHandler)
 	removedHandler.On("Handle", mock.AnythingOfType("*functioncall.SfcCrossCall")).Once().Return(nil)
 
-	watcher, err := NewSFCCrossCallRealtimeEventWatcher(auth.Context, handler, removedHandler, contract, make(chan bool))
+	opts := EventWatcherOpts{
+		Context:      auth.Context,
+		EventHandler: handler,
+	}
+	watcher, err := NewSFCCrossCallRealtimeEventWatcher(opts, removedHandler, contract, make(chan bool))
 	assert.Nil(t, err, "failed to create a realtime event watcher")
 	go watcher.Watch()
+	defer watcher.StopWatcher()
 
 	b1 := simBackend.Blockchain().CurrentBlock().Hash()
 
@@ -84,24 +114,28 @@ func TestSFCCrossCallRealtimeEventWatcher_RemovedEvent(t *testing.T) {
 
 func TestSFCCrossCallFinalisedEventWatcher_FailsIfConfirmationTooLow(t *testing.T) {
 	handler := new(MockEventHandler)
-	_, err := NewSFCCrossCallFinalisedEventWatcher(nil, 0, handler, nil, 0,
-		nil, make(chan bool))
+	opts := EventWatcherOpts{EventHandler: handler}
+	_, err := NewSFCCrossCallFinalisedEventWatcher(opts, DefaultWatcherProgressDsOpts, 0, nil, nil, nil)
 	assert.NotNil(t, err)
 }
 
 func TestSFCCrossCallFinalisedEventWatcher_FailsIfEventHandlerNil(t *testing.T) {
-	_, err := NewSFCCrossCallFinalisedEventWatcher(nil, 2, nil, nil, 0,
-		nil, make(chan bool))
+	opts := EventWatcherOpts{EventHandler: nil}
+	_, err := NewSFCCrossCallFinalisedEventWatcher(opts, DefaultWatcherProgressDsOpts, 2, nil, nil, nil)
 	assert.NotNil(t, err)
 }
 
 // tests the watcher behaviour under different confirmation number settings
 func TestSFCCrossCallFinalisedEventWatcher(t *testing.T) {
-	cases := map[string]struct{ confirmations, start uint64 }{
-		"1 Confirmation":  {1, 2},
-		"2 Confirmations": {2, 1},
-		"6 Confirmations": {6, 1},
+	cases := map[string]struct{ confirmations, start, lastFinalised uint64 }{
+		"1 Confirmation":  {1, 2, 2},
+		"2 Confirmations": {2, 1, 2},
+		"6 Confirmations": {6, 1, 2},
 	}
+	progOpts := DefaultWatcherProgressDsOpts
+	ds, dsClose := newDS(t)
+	defer dsClose()
+	progOpts.ds = ds
 
 	for k, v := range cases {
 		logging.Info("testing scenario: %s", k)
@@ -110,8 +144,14 @@ func TestSFCCrossCallFinalisedEventWatcher(t *testing.T) {
 		simBackend, auth := simulatedBackend(t)
 		contract := deployContract(t, simBackend, auth)
 
-		watcher, e := NewSFCCrossCallFinalisedEventWatcher(auth.Context, v.confirmations, handler, contract, v.start,
-			simBackend, make(chan bool))
+		opts := EventWatcherOpts{
+			Start:        v.start,
+			Context:      auth.Context,
+			EventHandler: handler,
+		}
+
+		progOpts.dsProgKey = datastore.NewKey(k)
+		watcher, e := NewSFCCrossCallFinalisedEventWatcher(opts, progOpts, v.confirmations, contract, simBackend, make(chan bool))
 		assert.Nil(t, e)
 		go watcher.Watch()
 
@@ -123,18 +163,28 @@ func TestSFCCrossCallFinalisedEventWatcher(t *testing.T) {
 		handler.On("Handle", mock.AnythingOfType("*functioncall.SfcCrossCall")).Once().Return(nil)
 		commitAndSleep(simBackend)
 		handler.AssertExpectations(t)
+		watcher.StopWatcher()
+
+		// Test that the progress of the watcher is persisted correctly
+		progress, err := watcher.GetSavedProgress()
+		assert.Nil(t, err)
+		assert.Equal(t, v.lastFinalised, progress)
 	}
 }
 
 // tests scenarios where events in multiple blocks have been finalised but not yet been processed
 func TestSFCCrossCallFinalisedEventWatcher_MultipleBlocksFinalised(t *testing.T) {
 	cases := map[string]struct {
-		confirmations, start                uint64
+		confirmations, start, lastFinalised uint64
 		ccEventsToCommit, expectedFinalised int
 	}{
-		"Multi-Block-Event-Finalisation-with-1-Confirmation":  {1, 0, 4, 4},
-		"Multi-Block-Event-Finalisation-with-2-Confirmations": {2, 0, 4, 3},
+		"Multi-Block-Event-Finalisation-with-1-Confirmation":  {1, 0, 6, 4, 4},
+		"Multi-Block-Event-Finalisation-with-2-Confirmations": {2, 0, 5, 4, 3},
 	}
+	progOpts := DefaultWatcherProgressDsOpts
+	ds, dsClose := newDS(t)
+	defer dsClose()
+	progOpts.ds = ds
 
 	for k, v := range cases {
 		logging.Info("testing scenario: %s", k)
@@ -148,16 +198,70 @@ func TestSFCCrossCallFinalisedEventWatcher_MultipleBlocksFinalised(t *testing.T)
 			commit(simBackend)
 			makeCrossContractCallTx(t, contract, auth)
 		}
-
-		watcher, e := NewSFCCrossCallFinalisedEventWatcher(auth.Context, v.confirmations, handler, contract, v.start,
-			simBackend, make(chan bool))
+		opts := EventWatcherOpts{
+			Start:        v.start,
+			Context:      auth.Context,
+			EventHandler: handler,
+		}
+		progOpts.dsProgKey = datastore.NewKey(k)
+		watcher, e := NewSFCCrossCallFinalisedEventWatcher(opts, progOpts, v.confirmations, contract, simBackend, make(chan bool))
 		assert.Nil(t, e)
 		go watcher.Watch()
 
 		handler.On("Handle", mock.AnythingOfType("*functioncall.SfcCrossCall")).Times(v.expectedFinalised).Return(nil)
 		commitAndSleep(simBackend)
 		handler.AssertExpectations(t)
+		watcher.StopWatcher()
+
+		// Test that the progress of the watcher is persisted correctly
+		progress, err := watcher.GetSavedProgress()
+		assert.Nil(t, err)
+		assert.Equal(t, v.lastFinalised, progress)
 	}
+}
+
+func TestSFCCrossCallFinalisedEventWatcher_ProgressPersistence(t *testing.T) {
+	simBackend, auth := simulatedBackend(t)
+	contract := deployContract(t, simBackend, auth)
+	fixConfirms := uint64(2)
+	fixLastFinalised := uint64(2)
+
+	handler := new(MockEventHandler)
+
+	opts := EventWatcherOpts{
+		Start:        0,
+		Context:      auth.Context,
+		EventHandler: handler,
+	}
+
+	progOpts := DefaultWatcherProgressDsOpts
+	ds, dsClose := newDS(t)
+	defer dsClose()
+	progOpts.ds = ds
+	progOpts.dsProgKey = datastore.NewKey("test_watcher_progress")
+
+	watcher, e := NewSFCCrossCallFinalisedEventWatcher(opts, progOpts, fixConfirms, contract, simBackend, make(chan bool))
+	assert.Nil(t, e)
+
+	go watcher.Watch()
+	makeCrossContractCallTx(t, contract, auth)
+	mineConfirmingBlocks(fixConfirms-1, simBackend)
+	handler.On("Handle", mock.AnythingOfType("*functioncall.SfcCrossCall")).Once().Return(nil)
+	commitAndSleep(simBackend)
+	handler.AssertExpectations(t)
+	watcher.StopWatcher()
+
+	// Test that the progress of the watcher is persisted correctly
+	progress, err := watcher.GetSavedProgress()
+	assert.Nil(t, err)
+	assert.Equal(t, fixLastFinalised, progress)
+
+	// Test that the saved progress is used when restarting a new watcher
+	newWatcher, e := NewSFCCrossCallFinalisedEventWatcher(opts, progOpts, fixConfirms, contract, simBackend, make(chan bool))
+	go newWatcher.Watch()
+	time.Sleep(1 * time.Second)
+	assert.Equal(t, progress+1, newWatcher.GetNextBlockToProcess())
+	newWatcher.StopWatcher()
 }
 
 /*
@@ -171,10 +275,22 @@ func TestSFCCrossCallFinalisedEventWatcher_Reorg(t *testing.T) {
 	simBackend, auth := simulatedBackend(t)
 	handler := new(MockEventHandler)
 	contract := deployContract(t, simBackend, auth)
+	opts := EventWatcherOpts{
+		Start:        2,
+		Context:      auth.Context,
+		EventHandler: handler,
+	}
 
-	watcher, e := NewSFCCrossCallFinalisedEventWatcher(auth.Context, 2, handler, contract, 1, simBackend, make(chan bool))
+	progOpts := DefaultWatcherProgressDsOpts
+	ds, dsClose := newDS(t)
+	defer dsClose()
+	progOpts.ds = ds
+	progOpts.dsProgKey = datastore.NewKey("reorg_test")
+
+	watcher, e := NewSFCCrossCallFinalisedEventWatcher(opts, progOpts, 2, contract, simBackend, make(chan bool))
 	assert.Nil(t, e)
 	go watcher.Watch()
+	defer watcher.StopWatcher()
 
 	b1 := simBackend.Blockchain().CurrentBlock().Hash()
 	makeCrossContractCallTx(t, contract, auth)

--- a/services/relayer/internal/msgobserver/eth/observer/event_watcher_test.go
+++ b/services/relayer/internal/msgobserver/eth/observer/event_watcher_test.go
@@ -115,13 +115,13 @@ func TestSFCCrossCallRealtimeEventWatcher_RemovedEvent(t *testing.T) {
 func TestSFCCrossCallFinalisedEventWatcher_FailsIfConfirmationTooLow(t *testing.T) {
 	handler := new(MockEventHandler)
 	opts := EventWatcherOpts{EventHandler: handler}
-	_, err := NewSFCCrossCallFinalisedEventWatcher(opts, DefaultWatcherProgressDsOpts, 0, nil, nil, nil)
+	_, err := NewSFCCrossCallFinalisedEventWatcher(opts, DefaultWatcherProgressDsOpts, DefaultEventHandleRetryOpts, 0, nil, nil, nil)
 	assert.NotNil(t, err)
 }
 
 func TestSFCCrossCallFinalisedEventWatcher_FailsIfEventHandlerNil(t *testing.T) {
 	opts := EventWatcherOpts{EventHandler: nil}
-	_, err := NewSFCCrossCallFinalisedEventWatcher(opts, DefaultWatcherProgressDsOpts, 2, nil, nil, nil)
+	_, err := NewSFCCrossCallFinalisedEventWatcher(opts, DefaultWatcherProgressDsOpts, DefaultEventHandleRetryOpts, 2, nil, nil, nil)
 	assert.NotNil(t, err)
 }
 
@@ -151,7 +151,8 @@ func TestSFCCrossCallFinalisedEventWatcher(t *testing.T) {
 		}
 
 		progOpts.dsProgKey = datastore.NewKey(k)
-		watcher, e := NewSFCCrossCallFinalisedEventWatcher(opts, progOpts, v.confirmations, contract, simBackend, make(chan bool))
+		watcher, e := NewSFCCrossCallFinalisedEventWatcher(opts, progOpts, DefaultEventHandleRetryOpts, v.confirmations, contract, simBackend,
+			make(chan bool))
 		assert.Nil(t, e)
 		go watcher.Watch()
 
@@ -204,7 +205,8 @@ func TestSFCCrossCallFinalisedEventWatcher_MultipleBlocksFinalised(t *testing.T)
 			EventHandler: handler,
 		}
 		progOpts.dsProgKey = datastore.NewKey(k)
-		watcher, e := NewSFCCrossCallFinalisedEventWatcher(opts, progOpts, v.confirmations, contract, simBackend, make(chan bool))
+		watcher, e := NewSFCCrossCallFinalisedEventWatcher(opts, progOpts, DefaultEventHandleRetryOpts, v.confirmations, contract, simBackend,
+			make(chan bool))
 		assert.Nil(t, e)
 		go watcher.Watch()
 
@@ -240,7 +242,8 @@ func TestSFCCrossCallFinalisedEventWatcher_ProgressPersistence(t *testing.T) {
 	progOpts.ds = ds
 	progOpts.dsProgKey = datastore.NewKey("test_watcher_progress")
 
-	watcher, e := NewSFCCrossCallFinalisedEventWatcher(opts, progOpts, fixConfirms, contract, simBackend, make(chan bool))
+	watcher, e := NewSFCCrossCallFinalisedEventWatcher(opts, progOpts, DefaultEventHandleRetryOpts, fixConfirms, contract, simBackend,
+		make(chan bool))
 	assert.Nil(t, e)
 
 	go watcher.Watch()
@@ -257,7 +260,8 @@ func TestSFCCrossCallFinalisedEventWatcher_ProgressPersistence(t *testing.T) {
 	assert.Equal(t, fixLastFinalised, progress)
 
 	// Test that the saved progress is used when restarting a new watcher
-	newWatcher, e := NewSFCCrossCallFinalisedEventWatcher(opts, progOpts, fixConfirms, contract, simBackend, make(chan bool))
+	newWatcher, e := NewSFCCrossCallFinalisedEventWatcher(opts, progOpts, DefaultEventHandleRetryOpts, fixConfirms, contract, simBackend,
+		make(chan bool))
 	go newWatcher.Watch()
 	time.Sleep(1 * time.Second)
 	assert.Equal(t, progress+1, newWatcher.GetNextBlockToProcess())
@@ -287,7 +291,7 @@ func TestSFCCrossCallFinalisedEventWatcher_Reorg(t *testing.T) {
 	progOpts.ds = ds
 	progOpts.dsProgKey = datastore.NewKey("reorg_test")
 
-	watcher, e := NewSFCCrossCallFinalisedEventWatcher(opts, progOpts, 2, contract, simBackend, make(chan bool))
+	watcher, e := NewSFCCrossCallFinalisedEventWatcher(opts, progOpts, DefaultEventHandleRetryOpts, 2, contract, simBackend, make(chan bool))
 	assert.Nil(t, e)
 	go watcher.Watch()
 	defer watcher.StopWatcher()

--- a/services/relayer/internal/msgobserver/eth/observer/event_watcher_test.go
+++ b/services/relayer/internal/msgobserver/eth/observer/event_watcher_test.go
@@ -31,9 +31,8 @@ type MockEventHandler struct {
 	mock.Mock
 }
 
-func (m *MockEventHandler) Handle(event interface{}) error {
-	args := m.Called(event)
-	return args.Error(0)
+func (m *MockEventHandler) Handle(event interface{}) {
+	m.Called(event)
 }
 
 func TestSFCCrossCallRealtimeEventWatcher(t *testing.T) {

--- a/services/relayer/internal/msgobserver/eth/observer/message_handler.go
+++ b/services/relayer/internal/msgobserver/eth/observer/message_handler.go
@@ -16,33 +16,52 @@ package observer
  */
 
 import (
+	"github.com/avast/retry-go"
 	"github.com/consensys/gpact/messaging/relayer/internal/logging"
 	v1 "github.com/consensys/gpact/messaging/relayer/internal/messages/v1"
 	"github.com/consensys/gpact/messaging/relayer/internal/mqserver"
+	"time"
 )
 
 // MessageHandler processes relayer messages
 type MessageHandler interface {
-	Handle(m *v1.Message) error
+	Handle(m *v1.Message)
 }
 
 // MessageEnqueueHandler enqueues relayer messages onto a configured message queue server
 type MessageEnqueueHandler struct {
-	MQ mqserver.MessageQueue
+	MQ            mqserver.MessageQueue
+	RetryAttempts uint
+	RetryDelay    time.Duration
 }
 
 // Handle sends the provided message to the configured message queue.
+// If sending the message fails, it is retried `MessageEnqueueHandler.retryAttempts` times.
 // The method assumes that the message queue is configured and started.
-func (mq *MessageEnqueueHandler) Handle(m *v1.Message) error {
-	mq.sendMessage(m)
-	return nil
+func (h *MessageEnqueueHandler) Handle(m *v1.Message) {
+	h.sendAsyncWithRetry(m)
+}
+
+// sendAsyncWithRetry starts a go routine that sends the given message to a queue, and retries if it fails.
+func (h *MessageEnqueueHandler) sendAsyncWithRetry(msg *v1.Message) {
+	logging.Info("Sending message to queue. Message ID: %s\n", msg.ID)
+	go func() {
+		err := retry.Do(
+			func() error {
+				return h.MQ.Request(v1.Version, v1.MessageType, msg)
+			},
+			retry.Attempts(h.RetryAttempts),
+			retry.Delay(h.RetryDelay),
+			retry.OnRetry(func(attempt uint, err error) {
+				logging.Info("Retrying sending message. ID: %s, Attempt: %d, Error: %v", msg.ID, attempt, err)
+			}))
+		if err != nil {
+			logging.Error("Failed to send message. ID: %s. Error: %v", msg.ID, err)
+			return
+		}
+	}()
 }
 
 func NewMessageEnqueueHandler(qServer mqserver.MessageQueue) *MessageEnqueueHandler {
-	return &MessageEnqueueHandler{qServer}
-}
-
-func (s *MessageEnqueueHandler) sendMessage(msg *v1.Message) {
-	logging.Info("Send message with ID: %s\n", msg.ID)
-	s.MQ.Request(v1.Version, v1.MessageType, msg)
+	return &MessageEnqueueHandler{qServer, 10, time.Second}
 }

--- a/services/relayer/internal/msgobserver/eth/observer/message_handler_test.go
+++ b/services/relayer/internal/msgobserver/eth/observer/message_handler_test.go
@@ -17,9 +17,9 @@ package observer
 
 import (
 	"testing"
+	"time"
 
 	v1 "github.com/consensys/gpact/messaging/relayer/internal/messages/v1"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestMessageEnqueueHandler(t *testing.T) {
@@ -36,8 +36,8 @@ func TestMessageEnqueueHandler(t *testing.T) {
 
 	mockMQ.On("Request", fixMsg.Version, fixMsg.MsgType, &fixMsg).Once()
 	handler := NewMessageEnqueueHandler(mockMQ)
-	err := handler.Handle(&fixMsg)
-	assert.Nil(t, err)
+	handler.Handle(&fixMsg)
 
+	time.Sleep(time.Second)
 	mockMQ.AssertExpectations(t)
 }

--- a/services/relayer/internal/msgobserver/eth/observer/message_handler_test.go
+++ b/services/relayer/internal/msgobserver/eth/observer/message_handler_test.go
@@ -16,6 +16,7 @@ package observer
  */
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -34,10 +35,31 @@ func TestMessageEnqueueHandler(t *testing.T) {
 
 	mockMQ := new(MockMQ)
 
-	mockMQ.On("Request", fixMsg.Version, fixMsg.MsgType, &fixMsg).Once()
-	handler := NewMessageEnqueueHandler(mockMQ)
+	mockMQ.On("Request", fixMsg.Version, fixMsg.MsgType, &fixMsg).Once().Return(nil)
+	handler := NewMessageEnqueueHandler(mockMQ, DefaultRetryOptions)
 	handler.Handle(&fixMsg)
 
 	time.Sleep(time.Second)
+	mockMQ.AssertExpectations(t)
+}
+func TestMessageEnqueueHandler_RetryOnFailure(t *testing.T) {
+	fixMsg := v1.Message{
+		ID:          "msg-0001",
+		Timestamp:   2384923489234,
+		MsgType:     v1.MessageType,
+		Version:     v1.Version,
+		Destination: v1.ApplicationAddress{NetworkID: "network-001"},
+		Source:      v1.ApplicationAddress{NetworkID: "network-002"},
+	}
+
+	mockMQ := new(MockMQ)
+
+	retryOpts := FailureRetryOpts{RetryDelay: 100 * time.Millisecond, RetryAttempts: 3}
+	mockMQ.On("Request", fixMsg.Version, fixMsg.MsgType, &fixMsg).
+		Times(int(retryOpts.RetryAttempts)).Return(fmt.Errorf("transient failure when calling handler"))
+	handler := NewMessageEnqueueHandler(mockMQ, retryOpts)
+	handler.Handle(&fixMsg)
+
+	time.Sleep(2 * time.Second)
 	mockMQ.AssertExpectations(t)
 }

--- a/services/relayer/internal/msgobserver/eth/observer/message_observer_test.go
+++ b/services/relayer/internal/msgobserver/eth/observer/message_observer_test.go
@@ -40,7 +40,7 @@ func TestSFCBridgeObserver(t *testing.T) {
 	assert.Nil(t, err)
 	go observer.Start()
 
-	mockMQ.On("Request", v1.Version, v1.MessageType, mock.AnythingOfType("*v1.Message")).Once()
+	mockMQ.On("Request", v1.Version, v1.MessageType, mock.AnythingOfType("*v1.Message")).Once().Return(nil)
 
 	_, err = contract.SfcTransactor.CrossBlockchainCall(auth, fixDestID, fixDesAddress, []byte("payload"))
 	if err != nil {

--- a/services/relayer/internal/msgobserver/eth/observer/utils.go
+++ b/services/relayer/internal/msgobserver/eth/observer/utils.go
@@ -17,7 +17,8 @@ package observer
 
 import (
 	"encoding/base64"
-
+	"encoding/binary"
+	"fmt"
 	"github.com/consensys/gpact/messaging/relayer/internal/crypto"
 )
 
@@ -29,4 +30,20 @@ func randomBytes(n int) []byte {
 
 func toBase64String(data []byte) string {
 	return base64.StdEncoding.EncodeToString(data)
+}
+
+func uintToBytes(n uint64) []byte {
+	b := make([]byte, binary.MaxVarintLen64)
+	binary.PutUvarint(b, n)
+	return b
+}
+
+func bytesToUint(buff []byte) (uint64, error) {
+	val, read := binary.Uvarint(buff)
+	if read == 0 {
+		return val, fmt.Errorf("error deserialising bytes to Uint: Byte buffer too small")
+	} else if read < 0 {
+		return val, fmt.Errorf("error deserialising bytes to Uint: Overflow error")
+	}
+	return val, nil
 }

--- a/services/relayer/internal/msgobserver/eth/observer/utils_test.go
+++ b/services/relayer/internal/msgobserver/eth/observer/utils_test.go
@@ -34,9 +34,10 @@ type MockMQ struct {
 	LastMessage messages.Message
 }
 
-func (mk *MockMQ) Request(version string, msgType string, msg messages.Message) {
+func (mk *MockMQ) Request(version string, msgType string, msg messages.Message) error {
 	mk.LastMessage = msg
 	mk.Called(version, msgType, msg)
+	return nil
 }
 
 func (mk *MockMQ) Start() error {

--- a/services/relayer/internal/msgobserver/eth/observer/utils_test.go
+++ b/services/relayer/internal/msgobserver/eth/observer/utils_test.go
@@ -36,8 +36,8 @@ type MockMQ struct {
 
 func (mk *MockMQ) Request(version string, msgType string, msg messages.Message) error {
 	mk.LastMessage = msg
-	mk.Called(version, msgType, msg)
-	return nil
+	args := mk.Called(version, msgType, msg)
+	return args.Error(0)
 }
 
 func (mk *MockMQ) Start() error {

--- a/services/relayer/internal/msgobserver/eth/observer/utils_test.go
+++ b/services/relayer/internal/msgobserver/eth/observer/utils_test.go
@@ -16,7 +16,10 @@ package observer
  */
 
 import (
+	badger "github.com/ipfs/go-ds-badger"
+	"io/ioutil"
 	"math/big"
+	"os"
 	"testing"
 
 	"github.com/consensys/gpact/messaging/relayer/internal/contracts/functioncall"
@@ -78,4 +81,20 @@ func deployContract(t *testing.T, simBackend *backends.SimulatedBackend, auth *b
 func failNow(t *testing.T, message string, args ...interface{}) {
 	t.Errorf(message, args...)
 	t.FailNow()
+}
+
+func newDS(t *testing.T) (*badger.Datastore, func()) {
+	path, err := ioutil.TempDir(os.TempDir(), "testing_badger_")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := badger.NewDatastore(path, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d, func() {
+		d.Close()
+		os.RemoveAll(path)
+	}
 }

--- a/services/relayer/internal/msgrelayer/eth/mq/handler_v1.go
+++ b/services/relayer/internal/msgrelayer/eth/mq/handler_v1.go
@@ -97,7 +97,7 @@ func handleV1(req messages.Message) {
 	})
 
 	// Pass message to MQ.
-	instance.MQ.Request(msg.Version, msg.MsgType, msg)
+	go instance.MQ.Request(msg.Version, msg.MsgType, msg)
 }
 
 // initV1 inits the handler.


### PR DESCRIPTION
This PR improves the resilience of the message observer to transient and partial failures. Specifically: 
1. it adds basic retry logic for failures that occur during fetching and processing events
2. it persists the progress of the observer to enable recovery in the event of failures and restarts. 

The PR also improves on existing tests and code documentation. 