### PR TITLE
Change the default watcher used by the observer

### DIFF
--- a/services/relayer/internal/msgobserver/eth/observer/message_handler.go
+++ b/services/relayer/internal/msgobserver/eth/observer/message_handler.go
@@ -20,22 +20,11 @@ import (
 	"github.com/consensys/gpact/messaging/relayer/internal/logging"
 	v1 "github.com/consensys/gpact/messaging/relayer/internal/messages/v1"
 	"github.com/consensys/gpact/messaging/relayer/internal/mqserver"
-	"time"
 )
 
 // MessageHandler processes relayer messages
 type MessageHandler interface {
 	Handle(m *v1.Message)
-}
-
-type FailureRetryOpts struct {
-	RetryAttempts uint
-	RetryDelay    time.Duration
-}
-
-var DefaultRetryOptions = FailureRetryOpts{
-	RetryAttempts: 5,
-	RetryDelay:    500 * time.Millisecond,
 }
 
 // MessageEnqueueHandler enqueues relayer messages onto a configured message queue server

--- a/services/relayer/internal/msgobserver/eth/observer/message_observer.go
+++ b/services/relayer/internal/msgobserver/eth/observer/message_observer.go
@@ -25,21 +25,42 @@ import (
 // SFCBridgeObserver listens to incoming events from an SFC contract, transforms them into relayer messages
 // and then enqueues them onto a message queue them for further processing by other Relayer components
 type SFCBridgeObserver struct {
-	EventWatcher  *SFCCrossCallRealtimeEventWatcher
-	EventHandler  *SimpleEventHandler
+	EventWatcher  EventWatcher
+	EventHandler  EventHandler
 	SourceNetwork string
 }
 
-func NewSFCBridgeObserver(source string, sourceAddr string, contract *functioncall.Sfc, mq mqserver.MessageQueue) (*SFCBridgeObserver, error) {
+func NewSFCBridgeRealtimeObserver(source string, sourceAddr string, contract *functioncall.Sfc, mq mqserver.MessageQueue) (*SFCBridgeObserver, error) {
 	eventTransformer := NewSFCEventTransformer(source, sourceAddr)
 	messageHandler := NewMessageEnqueueHandler(mq, DefaultRetryOptions)
 	eventHandler := NewSimpleEventHandler(eventTransformer, messageHandler)
 	removedEvHandler := NewLogEventHandler("removed event")
-	eventWatcher, err := NewSFCCrossCallRealtimeEventWatcher(EventWatcherOpts{Context: context.Background(), EventHandler: eventHandler},
-		removedEvHandler, contract)
+
+	// TODO: expose the start option of watcher opts
+	watcherOpts := EventWatcherOpts{Context: context.Background(), EventHandler: eventHandler}
+	eventWatcher, err := NewSFCCrossCallRealtimeEventWatcher(watcherOpts, removedEvHandler, contract)
 	if err != nil {
 		return nil, err
 	}
+
+	return &SFCBridgeObserver{EventWatcher: eventWatcher, EventHandler: eventHandler, SourceNetwork: source}, nil
+}
+
+func NewSFCBridgeFinalisedObserver(source string, sourceAddr string, contract *functioncall.Sfc, mq mqserver.MessageQueue,
+	confirmationsForFinality uint64, watcherProgressOpts WatcherProgressDsOpts, client BlockHeadProducer) (
+	*SFCBridgeObserver,
+	error) {
+	eventTransformer := NewSFCEventTransformer(source, sourceAddr)
+	messageHandler := NewMessageEnqueueHandler(mq, DefaultRetryOptions)
+	eventHandler := NewSimpleEventHandler(eventTransformer, messageHandler)
+
+	// TODO: expose the start option of watcher opts
+	watcherOpts := EventWatcherOpts{Context: context.Background(), EventHandler: eventHandler}
+	eventWatcher, err := NewSFCCrossCallFinalisedEventWatcher(watcherOpts, watcherProgressOpts, DefaultRetryOptions, confirmationsForFinality, contract, client)
+	if err != nil {
+		return nil, err
+	}
+
 	return &SFCBridgeObserver{EventWatcher: eventWatcher, EventHandler: eventHandler, SourceNetwork: source}, nil
 }
 

--- a/services/relayer/internal/msgobserver/eth/observer/message_observer_test.go
+++ b/services/relayer/internal/msgobserver/eth/observer/message_observer_test.go
@@ -36,7 +36,7 @@ func TestSFCBridgeObserver(t *testing.T) {
 	contract := deployContract(t, simBackend, auth)
 	mockMQ := new(MockMQ)
 
-	observer, err := NewSFCBridgeObserver(fixSourceID, fixSourceAddress, contract, mockMQ)
+	observer, err := NewSFCBridgeRealtimeObserver(fixSourceID, fixSourceAddress, contract, mockMQ)
 	assert.Nil(t, err)
 	go observer.Start()
 

--- a/services/relayer/internal/msgobserver/eth/observer/observer_impl_v1.go
+++ b/services/relayer/internal/msgobserver/eth/observer/observer_impl_v1.go
@@ -155,7 +155,8 @@ func (o *ObserverImplV1) routine(chainID *big.Int, chainAP string, addr common.A
 			return
 		}
 
-		observer, err := NewSFCBridgeObserver(chainID.String(), addr.String(), sfc, o.mq)
+		observer, err := o.createFinalisedEventObserver(chainID.String(), addr.String(), sfc, o.mq, chain)
+
 		if err != nil {
 			logging.Error(err.Error())
 			return
@@ -169,6 +170,13 @@ func (o *ObserverImplV1) routine(chainID *big.Int, chainAP string, addr common.A
 			time.Sleep(3 * time.Second)
 		}
 	}
+}
+
+func (o *ObserverImplV1) createFinalisedEventObserver(source string, sourceAddr string, contract *functioncall.Sfc, mq mqserver.MessageQueue,
+	client *ethclient.Client) (*SFCBridgeObserver, error) {
+	dsProgKey := datastore.NewKey(fmt.Sprintf("/%s/%s/last_finalised_block", source, sourceAddr))
+	watcherProgOpts := WatcherProgressDsOpts{o.ds, dsProgKey, DefaultRetryOptions}
+	return NewSFCBridgeFinalisedObserver(source, sourceAddr, contract, mq, 4, watcherProgOpts, client)
 }
 
 // dsKey gets the datastore key from given chainID and contract address.

--- a/services/relayer/internal/msgobserver/eth/observer/retry_opts.go
+++ b/services/relayer/internal/msgobserver/eth/observer/retry_opts.go
@@ -1,0 +1,13 @@
+package observer
+
+import "time"
+
+type FailureRetryOpts struct {
+	RetryAttempts uint
+	RetryDelay    time.Duration
+}
+
+var DefaultRetryOptions = FailureRetryOpts{
+	RetryAttempts: 5,
+	RetryDelay:    300 * time.Millisecond,
+}


### PR DESCRIPTION
This PR changes the default watcher used by the observer from [Realtime Event Watcher](https://github.com/ConsenSys/gpact/blob/main/docs/message-observer.md#realtime-event-watcher) to [Finalised Event Watcher](https://github.com/ConsenSys/gpact/blob/main/docs/message-observer.md#finalised-event-watcher). Unlike the Realtime Event Watcher, a Finalised Event Watcher offers better assurances around the finality of events by waiting for a configurable number of confirmations prior to relaying events. 

Future PRs will make changing the specific watcher types to use more configurable. 