### PR TITLE
Ensure logger reports the correct file and line number of caller

### DIFF
--- a/services/message-store/internal/logging/logging.go
+++ b/services/message-store/internal/logging/logging.go
@@ -38,7 +38,7 @@ func Init(conf *viper.Viper) zerolog.Logger {
 	writer := getLogTarget(conf)
 	service := getLogServiceName(conf)
 	logger := zerolog.New(writer).With().Timestamp().Str("service", service).Logger()
-	log.Logger = logger.With().Caller().Logger()
+	log.Logger = logger.With().CallerWithSkipFrameCount(3).Logger()
 	return logger
 }
 

--- a/services/relayer/internal/logging/logging.go
+++ b/services/relayer/internal/logging/logging.go
@@ -38,7 +38,7 @@ func Init(conf *viper.Viper) zerolog.Logger {
 	writer := getLogTarget(conf)
 	service := getLogServiceName(conf)
 	logger := zerolog.New(writer).With().Timestamp().Str("service", service).Logger()
-	log.Logger = logger.With().Caller().Logger()
+	log.Logger = logger.With().CallerWithSkipFrameCount(3).Logger()
 	return logger
 }
 


### PR DESCRIPTION
Currently, we use a [wrapper](https://github.com/ConsenSys/gpact/blob/main/services/relayer/internal/logging/logging.go) around zerolog in order to have a more convenient logging API to use. This, however, results in the wrapper's file and line numbers being reported in logs instead of the caller's. This PR addresses this issue.