### PR TITLE
Simplify message ID generated by Relayer

### DIFF
--- a/docs/message-observer.md
+++ b/docs/message-observer.md
@@ -93,7 +93,8 @@ However, the degree to which the ID scheme can guarantee the above properties is
 mitigating the possibility of reorgs.
 
 The current ID scheme implemented for a message involves the following structure: 
-`{network_id}-{contract_address}-{block_number}-{tx_index}-{log_index}`.
+`{network_id}-{contract_address}-{block_number}-{tx_index}-{log_index}`. 
+The contract address is a lowercase hex string and not in [EIP-55](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md) format.
 
 ### Message Handler
 

--- a/sdk/go/executor/executor_impl_v1.go
+++ b/sdk/go/executor/executor_impl_v1.go
@@ -432,5 +432,5 @@ func (exec *ExecutorImplV1) updateTransactOpts(chainAP *ethclient.Client) error 
 
 // getEventID gets the ID of an event.
 func getEventID(chainID *big.Int, raw types.Log) string {
-	return fmt.Sprintf("%s-%s-%d-%d-%d", chainID.String(), raw.Address.String(), raw.BlockNumber, raw.TxIndex, raw.Index)
+	return fmt.Sprintf("%s-%#x-%d-%d-%d", chainID.String(), raw.Address, raw.BlockNumber, raw.TxIndex, raw.Index)
 }

--- a/services/relayer/internal/msgobserver/eth/observer/event_transformer_test.go
+++ b/services/relayer/internal/msgobserver/eth/observer/event_transformer_test.go
@@ -43,7 +43,8 @@ var fixValidEvent = functioncall.SfcCrossCall{
 	Raw:              fixLog,
 }
 
-var transformer = NewSFCEventTransformer("network-001", "0x8e215d06ea7ec1fdb4fc5fd21768f4b34ee92ef4")
+var transformer = NewSFCEventTransformer("network-001",
+	common.HexToAddress("0x8e215d06ea7ec1fdb4fc5fd21768f4b34ee92ef4"))
 
 func TestSFCTransformer(t *testing.T) {
 	message, err := transformer.ToMessage(&fixValidEvent)

--- a/services/relayer/internal/msgobserver/eth/observer/message_observer.go
+++ b/services/relayer/internal/msgobserver/eth/observer/message_observer.go
@@ -17,6 +17,7 @@ package observer
 
 import (
 	"context"
+	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/consensys/gpact/services/relayer/internal/contracts/functioncall"
 	"github.com/consensys/gpact/services/relayer/internal/mqserver"
@@ -30,7 +31,8 @@ type SFCBridgeObserver struct {
 	SourceNetwork string
 }
 
-func NewSFCBridgeRealtimeObserver(source string, sourceAddr string, contract *functioncall.Sfc, mq mqserver.MessageQueue) (*SFCBridgeObserver, error) {
+func NewSFCBridgeRealtimeObserver(source string, sourceAddr common.Address, contract *functioncall.Sfc,
+	mq mqserver.MessageQueue) (*SFCBridgeObserver, error) {
 	eventTransformer := NewSFCEventTransformer(source, sourceAddr)
 	messageHandler := NewMessageEnqueueHandler(mq, DefaultRetryOptions)
 	eventHandler := NewSimpleEventHandler(eventTransformer, messageHandler)
@@ -46,7 +48,7 @@ func NewSFCBridgeRealtimeObserver(source string, sourceAddr string, contract *fu
 	return &SFCBridgeObserver{EventWatcher: eventWatcher, EventHandler: eventHandler, SourceNetwork: source}, nil
 }
 
-func NewSFCBridgeFinalisedObserver(source string, sourceAddr string, contract *functioncall.Sfc, mq mqserver.MessageQueue,
+func NewSFCBridgeFinalisedObserver(source string, sourceAddr common.Address, contract *functioncall.Sfc, mq mqserver.MessageQueue,
 	confirmationsForFinality uint64, watcherProgressOpts WatcherProgressDsOpts, client BlockHeadProducer) (
 	*SFCBridgeObserver,
 	error) {
@@ -81,7 +83,8 @@ type GPACTBridgeObserver struct {
 	SourceNetwork string
 }
 
-func NewGPACTBridgeRealtimeObserver(source string, sourceAddr string, contract *functioncall.Gpact, mq mqserver.MessageQueue) (*GPACTBridgeObserver, error) {
+func NewGPACTBridgeRealtimeObserver(source string, sourceAddr common.Address, contract *functioncall.Gpact,
+	mq mqserver.MessageQueue) (*GPACTBridgeObserver, error) {
 	eventTransformer := NewGPACTEventTransformer(source, sourceAddr)
 	messageHandler := NewMessageEnqueueHandler(mq, DefaultRetryOptions)
 	eventHandler := NewSimpleEventHandler(eventTransformer, messageHandler)

--- a/services/relayer/internal/msgobserver/eth/observer/message_observer_test.go
+++ b/services/relayer/internal/msgobserver/eth/observer/message_observer_test.go
@@ -31,7 +31,7 @@ func TestSFCBridgeObserver(t *testing.T) {
 	fixDesAddress := common.HexToAddress("0x8e215d06ea7ec1fdb4fc5fd21768f4b34ee92ef4")
 	fixDestID := big.NewInt(2)
 	fixSourceID := "1"
-	fixSourceAddress := "0x8e215d06ea7ec1fdb4fc5fd21768f4b34ee92ef4"
+	fixSourceAddress := common.HexToAddress("0x8e215d06ea7ec1fdb4fc5fd21768f4b34ee92ef4")
 
 	simBackend, auth := simulatedBackend(t)
 	contract := deploySFCContract(t, simBackend, auth)

--- a/services/relayer/internal/msgobserver/eth/observer/observer_impl_v1.go
+++ b/services/relayer/internal/msgobserver/eth/observer/observer_impl_v1.go
@@ -174,7 +174,7 @@ func (o *ObserverImplV1) routineSFC(chainID *big.Int, chainAP string, addr commo
 			return
 		}
 
-		observer, err := o.createFinalisedEventObserver(chainID.String(), addr.String(), sfc, o.mq, chain)
+		observer, err := o.createFinalisedEventObserver(chainID.String(), addr, sfc, o.mq, chain)
 
 		if err != nil {
 			logging.Error(err.Error())
@@ -207,7 +207,7 @@ func (o *ObserverImplV1) routineGPACT(chainID *big.Int, chainAP string, addr com
 			return
 		}
 
-		observer, err := NewGPACTBridgeRealtimeObserver(chainID.String(), addr.String(), gpact, o.mq)
+		observer, err := NewGPACTBridgeRealtimeObserver(chainID.String(), addr, gpact, o.mq)
 
 		if err != nil {
 			logging.Error(err.Error())
@@ -224,7 +224,8 @@ func (o *ObserverImplV1) routineGPACT(chainID *big.Int, chainAP string, addr com
 	}
 }
 
-func (o *ObserverImplV1) createFinalisedEventObserver(source string, sourceAddr string, contract *functioncall.Sfc, mq mqserver.MessageQueue,
+func (o *ObserverImplV1) createFinalisedEventObserver(source string, sourceAddr common.Address, contract *functioncall.Sfc,
+	mq mqserver.MessageQueue,
 	client *ethclient.Client) (*SFCBridgeObserver, error) {
 	dsProgKey := datastore.NewKey(fmt.Sprintf("/%s/%s/last_finalised_block", source, sourceAddr))
 	watcherProgOpts := WatcherProgressDsOpts{o.ds, dsProgKey, DefaultRetryOptions}


### PR DESCRIPTION
The message ID generated by a Relayer includes the contract address that generated the underlying transaction, as described [here](https://github.com/ConsenSys/gpact/blob/main/docs/message-observer.md#event-transformer). The formatting of the contract address follows [EIP-55](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md), with mixed-case letters in the string representation of the address. This PR moves towards a consistent case formatting of the hex address for simplicity. 