### PR TITLE
Add Java compilation to initial checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,41 @@ jobs:
 #          destination: distributions
 #          when: always
 
+
+  javasdk-build:
+    machine:
+      image: ubuntu-2004:202107-02
+    resource_class: medium
+    steps:
+      # The home directory is: /home/circleci/project
+      # gpact is cloned to: /home/circleci/project/.
+      # web3j is cloned to: /home/circleci/web3j-abi
+      - prepare
+      - run:
+          name: Build web3j
+          command: |
+            # Build our Web3j
+            cd ../web3j-abi
+            ./gradlew --parallel --stacktrace --info --build-cache installDist
+      - run:
+          name: Check code formatting, compile the code, everything but execute any tests
+          command: ./gradlew build -x test
+      - save_cache:
+          name: Caching Web3j gradle dependencies
+          key: deps-web3j-{{ checksum "../web3j-abi/build.gradle" }}
+          paths:
+            - ../web3j/.gradle
+      - save_cache:
+          name: Caching GPACT gradle dependencies
+          key: deps-gpact-{{ checksum "build.gradle" }}
+          paths:
+            - .gradle
+      - save_cache:
+          name: Caching gradle build cache
+          key: build-cache-{{ checksum "../besu/headcommit" }}-{{ checksum "../web3j-abi/headcommit" }}-{{ .Revision }}
+          paths:
+            - ~/.gradle
+
   unitTestsMachine:
     machine:
       image: ubuntu-2004:202107-02
@@ -116,9 +151,6 @@ jobs:
             # Build our Web3j
             cd ../web3j-abi
             ./gradlew --parallel --stacktrace --info --build-cache installDist
-      - run:
-          name: Check code formatting
-          command: ./gradlew solCheckFormat spotlessCheck
       - run:
           name: Create Relayer containers
           working_directory: services/relayer
@@ -283,11 +315,13 @@ workflows:
   default:
     jobs:
       - relayer-build
+      - javasdk-build
       - relayer-test:
           requires:
             - relayer-build
       - unitTestsMachine:
           requires:
             - relayer-build
+            - javasdk-build
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,51 +57,6 @@ commands:
 
 
 jobs:
-  build:
-    docker:
-      - image: cimg/openjdk:11.0.11
-    working_directory: ~/gpact
-    steps:
-      - prepare
-      - run:
-          name: Assemble
-          command: |
-            pushd .
-            # Build our Web3j
-            cd ../web3j-abi
-            ./gradlew --parallel --stacktrace --info --build-cache installDist
-            popd
-            # Build the gpact
-            ./gradlew --parallel --stacktrace --info --build-cache clean compileJava compileTestJava assemble
-      - save_cache:
-          name: Caching Web3j gradle dependencies
-          key: deps-web3j-{{ checksum "../web3j-abi/build.gradle" }}
-          paths:
-            - ../web3j/.gradle
-      - save_cache:
-          name: Caching GPACT gradle dependencies
-          key: deps-gpact-{{ checksum "build.gradle" }}
-          paths:
-            - .gradle
-      - save_cache:
-          name: Caching gradle build cache
-          key: build-cache-{{ checksum "../besu/headcommit" }}-{{ checksum "../web3j-abi/headcommit" }}-{{ .Revision }}
-          paths:
-            - ~/.gradle
-
-#      - persist_to_workspace:
-#          root: ~/
-#          paths:
-#            - ./gpact
-#            - ./web3j-abi
-            #           - ./besu/build/install
-#      - store_artifacts:
-#          name: Distribution artifacts
-#          path:  build/distributions
-#          destination: distributions
-#          when: always
-
-
   javasdk-build:
     machine:
       image: ubuntu-2004:202107-02
@@ -132,7 +87,7 @@ jobs:
             - .gradle
       - save_cache:
           name: Caching gradle build cache
-          key: build-cache-{{ checksum "../besu/headcommit" }}-{{ checksum "../web3j-abi/headcommit" }}-{{ .Revision }}
+          key: build-cache-{{ checksum "../web3j-abi/headcommit" }}-{{ .Revision }}
           paths:
             - ~/.gradle
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,9 @@ jobs:
             cd ../web3j-abi
             ./gradlew --parallel --stacktrace --info --build-cache installDist
       - run:
+          name: Check code formatting, compile the code, everything but execute any tests
+          command: ./gradlew build -x test
+      - run:
           name: Create Relayer containers
           working_directory: services/relayer
           command: make docker
@@ -270,13 +273,11 @@ workflows:
   default:
     jobs:
       - relayer-build
-      - javasdk-build
       - relayer-test:
           requires:
             - relayer-build
       - unitTestsMachine:
           requires:
             - relayer-build
-            - javasdk-build
 
 


### PR DESCRIPTION
Previously, the initial checks during the Java SDK build and test was to run solFormat and spotlessCheck. Adding in a compile takes almost no extra time. This is achieved by running: ./gradlew build -x test . This runs everything in the build process, except running the test code.

The advantage of doing this is finding out about compilation failures that IDEs might not be highlighting earlier in the build process.

There is an additional Circle CI target which only runs the ./gradlew build -x test  . Unfortunately, prior to running this Web3J needs to be built and Solidity needs to be installed. This results in the overall build being 1 1/2 minutes longer. Hence, this code is available for possible future use, but is not currently run.