### PR TITLE
Add GPACT v2 examples and tests

### DIFF
--- a/examples/gpact/conditional/java/src/intTest/java/net/consensys/gpact/examples/gpact/conditional/ConditionalTest.java
+++ b/examples/gpact/conditional/java/src/intTest/java/net/consensys/gpact/examples/gpact/conditional/ConditionalTest.java
@@ -37,4 +37,11 @@ public class ConditionalTest extends AbstractExampleTest {
     Main.main(
         new String[] {GpactCrossControlManagerGroup.GpactVersion.V1.toString(), tempPropsFile});
   }
+
+  @Test
+  public void fakeMessagingSerialMultiBlockchainGpactV2() throws Exception {
+    String tempPropsFile = createPropertiesFile(MessagingType.FAKE, true, false);
+    Main.main(
+        new String[] {GpactCrossControlManagerGroup.GpactVersion.V2.toString(), tempPropsFile});
+  }
 }

--- a/examples/gpact/erc20bridge/java/src/intTest/java/net/consensys/gpact/examples/gpact/erc20bridge/Erc20BridgeTest.java
+++ b/examples/gpact/erc20bridge/java/src/intTest/java/net/consensys/gpact/examples/gpact/erc20bridge/Erc20BridgeTest.java
@@ -16,6 +16,7 @@ package net.consensys.gpact.examples.gpact.erc20bridge;
 
 import net.consensys.gpact.functioncall.gpact.GpactCrossControlManagerGroup;
 import net.consensys.gpact.helpers.AbstractExampleTest;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class Erc20BridgeTest extends AbstractExampleTest {
@@ -34,6 +35,8 @@ public class Erc20BridgeTest extends AbstractExampleTest {
         new String[] {GpactCrossControlManagerGroup.GpactVersion.V1.toString(), tempPropsFile});
   }
 
+  // TODO: Skip until crosschain application authentication is working
+  @Disabled
   @Test
   public void fakeMessagingSerialMultiBlockchainGpactV2() throws Exception {
     String tempPropsFile = createPropertiesFile(MessagingType.FAKE, true, false);

--- a/examples/gpact/erc20bridge/java/src/intTest/java/net/consensys/gpact/examples/gpact/erc20bridge/Erc20BridgeTest.java
+++ b/examples/gpact/erc20bridge/java/src/intTest/java/net/consensys/gpact/examples/gpact/erc20bridge/Erc20BridgeTest.java
@@ -33,4 +33,11 @@ public class Erc20BridgeTest extends AbstractExampleTest {
     ERC20TokenBridgeExample.main(
         new String[] {GpactCrossControlManagerGroup.GpactVersion.V1.toString(), tempPropsFile});
   }
+
+  @Test
+  public void fakeMessagingSerialMultiBlockchainGpactV2() throws Exception {
+    String tempPropsFile = createPropertiesFile(MessagingType.FAKE, true, false);
+    ERC20TokenBridgeExample.main(
+        new String[] {GpactCrossControlManagerGroup.GpactVersion.V2.toString(), tempPropsFile});
+  }
 }

--- a/examples/gpact/erc20bridge/java/src/main/java/net/consensys/gpact/examples/gpact/erc20bridge/ERC20TokenBridgeExample.java
+++ b/examples/gpact/erc20bridge/java/src/main/java/net/consensys/gpact/examples/gpact/erc20bridge/ERC20TokenBridgeExample.java
@@ -82,7 +82,8 @@ public class ERC20TokenBridgeExample extends GpactExampleBase {
             chainA.getErc20ContractAddress(),
             bc2.bcId,
             chainB.getBridgeContractAddress(),
-            chainB.getErc20ContractAddress());
+            chainB.getErc20ContractAddress(),
+            exampleManager.getFunctionCallImplName());
     Erc20User user2 =
         new Erc20User(
             "User2",
@@ -91,7 +92,8 @@ public class ERC20TokenBridgeExample extends GpactExampleBase {
             chainA.getErc20ContractAddress(),
             bc2.bcId,
             chainB.getBridgeContractAddress(),
-            chainB.getErc20ContractAddress());
+            chainB.getErc20ContractAddress(),
+            exampleManager.getFunctionCallImplName());
     Erc20User user3 =
         new Erc20User(
             "User3",
@@ -100,7 +102,8 @@ public class ERC20TokenBridgeExample extends GpactExampleBase {
             chainA.getErc20ContractAddress(),
             bc2.bcId,
             chainB.getBridgeContractAddress(),
-            chainB.getErc20ContractAddress());
+            chainB.getErc20ContractAddress(),
+            exampleManager.getFunctionCallImplName());
 
     user1.createCbcManager(
         root,

--- a/examples/gpact/erc20bridge/java/src/main/java/net/consensys/gpact/examples/gpact/erc20bridge/Erc20User.java
+++ b/examples/gpact/erc20bridge/java/src/main/java/net/consensys/gpact/examples/gpact/erc20bridge/Erc20User.java
@@ -41,6 +41,7 @@ public class Erc20User {
 
   private BlockchainConfig bcInfoA;
   private BlockchainConfig bcInfoB;
+  private String gpactImplName;
 
   protected Erc20User(
       String name,
@@ -49,7 +50,8 @@ public class Erc20User {
       String erc20AddressA,
       BlockchainId bcIdB,
       String erc20BridgeAddressB,
-      String erc20AddressB)
+      String erc20AddressB,
+      String gpactImplName)
       throws Exception {
 
     this.name = name;
@@ -61,6 +63,8 @@ public class Erc20User {
 
     this.bcIdA = bcIdA;
     this.bcIdB = bcIdB;
+
+    this.gpactImplName = gpactImplName;
   }
 
   public void createCbcManager(
@@ -72,7 +76,7 @@ public class Erc20User {
       MessagingVerificationInterface msgVerB)
       throws Exception {
     this.crossControlManagerGroup =
-        CrosschainProtocols.getFunctionCallInstance(CrosschainProtocols.GPACT_V1).get();
+        CrosschainProtocols.getFunctionCallInstance(this.gpactImplName).get();
     this.crossControlManagerGroup.addBlockchainAndLoadCbcContract(
         this.creds, bcInfoA, cbcContractAddressOnBcA);
     this.crossControlManagerGroup.setMessageVerifier(bcInfoA.bcId, msgVerA);

--- a/examples/gpact/hotel-train/java/src/intTest/java/net/consensys/gpact/examples/gpact/hoteltrain/HotelTrainTest.java
+++ b/examples/gpact/hotel-train/java/src/intTest/java/net/consensys/gpact/examples/gpact/hoteltrain/HotelTrainTest.java
@@ -32,4 +32,11 @@ public class HotelTrainTest extends AbstractExampleTest {
     HotelTrain.main(
         new String[] {GpactCrossControlManagerGroup.GpactVersion.V1.toString(), tempPropsFile});
   }
+
+  @Test
+  public void fakeMessagingParallelMultiBlockchainGpactV2() throws Exception {
+    String tempPropsFile = createPropertiesFile(MessagingType.FAKE, false, false);
+    HotelTrain.main(
+        new String[] {GpactCrossControlManagerGroup.GpactVersion.V2.toString(), tempPropsFile});
+  }
 }

--- a/examples/gpact/hotel-train/java/src/intTest/java/net/consensys/gpact/examples/gpact/hoteltrain/HotelTrainTest.java
+++ b/examples/gpact/hotel-train/java/src/intTest/java/net/consensys/gpact/examples/gpact/hoteltrain/HotelTrainTest.java
@@ -2,6 +2,7 @@ package net.consensys.gpact.examples.gpact.hoteltrain;
 
 import net.consensys.gpact.functioncall.gpact.GpactCrossControlManagerGroup;
 import net.consensys.gpact.helpers.AbstractExampleTest;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class HotelTrainTest extends AbstractExampleTest {
@@ -33,6 +34,8 @@ public class HotelTrainTest extends AbstractExampleTest {
         new String[] {GpactCrossControlManagerGroup.GpactVersion.V1.toString(), tempPropsFile});
   }
 
+  // TODO requires crosschain authentication to work
+  @Disabled
   @Test
   public void fakeMessagingParallelMultiBlockchainGpactV2() throws Exception {
     String tempPropsFile = createPropertiesFile(MessagingType.FAKE, false, false);

--- a/examples/gpact/hotel-train/java/src/main/java/net/consensys/gpact/examples/gpact/hoteltrain/EntityTravelAgency.java
+++ b/examples/gpact/hotel-train/java/src/main/java/net/consensys/gpact/examples/gpact/hoteltrain/EntityTravelAgency.java
@@ -84,6 +84,7 @@ public class EntityTravelAgency extends AbstractBlockchain {
   }
 
   public void createCbcManager(
+      String funcCallImplName,
       BlockchainConfig bcInfoTravel,
       String cbcContractAddressOnBcTravel,
       MessagingVerificationInterface msgVerTravel,
@@ -95,7 +96,7 @@ public class EntityTravelAgency extends AbstractBlockchain {
       MessagingVerificationInterface msgVerTrain)
       throws Exception {
     this.crossControlManagerGroup =
-        CrosschainProtocols.getFunctionCallInstance(CrosschainProtocols.GPACT_V1).get();
+        CrosschainProtocols.getFunctionCallInstance(funcCallImplName).get();
     this.crossControlManagerGroup.addBlockchainAndLoadCbcContract(
         this.credentials, bcInfoTravel, cbcContractAddressOnBcTravel);
     this.crossControlManagerGroup.setMessageVerifier(bcInfoTravel.bcId, msgVerTravel);

--- a/examples/gpact/hotel-train/java/src/main/java/net/consensys/gpact/examples/gpact/hoteltrain/HotelTrain.java
+++ b/examples/gpact/hotel-train/java/src/main/java/net/consensys/gpact/examples/gpact/hoteltrain/HotelTrain.java
@@ -64,6 +64,7 @@ public class HotelTrain extends GpactExampleBase {
         train.getTrainContractAddress());
 
     travelAgency.createCbcManager(
+        exampleManager.getFunctionCallImplName(),
         root,
         crossControlManagerGroup.getCbcAddress(travelBcId),
         crossControlManagerGroup.getMessageVerification(travelBcId),

--- a/examples/gpact/read/java/src/intTest/java/net/consensys/gpact/examples/gpact/read/CrosschainRead.java
+++ b/examples/gpact/read/java/src/intTest/java/net/consensys/gpact/examples/gpact/read/CrosschainRead.java
@@ -68,4 +68,11 @@ public class CrosschainRead extends AbstractExampleTest {
     Main.main(
         new String[] {GpactCrossControlManagerGroup.GpactVersion.V1.toString(), tempPropsFile});
   }
+
+  @Test
+  public void fakeMessagingSerialMultiBlockchainGpactV2() throws Exception {
+    String tempPropsFile = createPropertiesFile(MessagingType.FAKE, true, false);
+    Main.main(
+        new String[] {GpactCrossControlManagerGroup.GpactVersion.V2.toString(), tempPropsFile});
+  }
 }

--- a/examples/gpact/trade/java/src/intTest/java/net/consensys/gpact/examples/gpact/trade/TradeTest.java
+++ b/examples/gpact/trade/java/src/intTest/java/net/consensys/gpact/examples/gpact/trade/TradeTest.java
@@ -81,11 +81,4 @@ public class TradeTest extends AbstractExampleTest {
     Main.main(
         new String[] {GpactCrossControlManagerGroup.GpactVersion.V2.toString(), tempPropsFile});
   }
-
-  @Test
-  public void fakeMessagingParallelMultiBlockchainGpactV1() throws Exception {
-    String tempPropsFile = createPropertiesFile(MessagingType.FAKE, false, false);
-    Main.main(
-        new String[] {GpactCrossControlManagerGroup.GpactVersion.V1.toString(), tempPropsFile});
-  }
 }

--- a/examples/gpact/write/java/src/intTest/java/net/consensys/gpact/examples/gpact/write/WriteTest.java
+++ b/examples/gpact/write/java/src/intTest/java/net/consensys/gpact/examples/gpact/write/WriteTest.java
@@ -73,11 +73,4 @@ public class WriteTest extends AbstractExampleTest {
     GpactCrosschainWrite.main(
         new String[] {GpactCrossControlManagerGroup.GpactVersion.V2.toString(), tempPropsFile});
   }
-
-  @Test
-  public void fakeMessagingParallelMultiBlockchainGpactV1() throws Exception {
-    String tempPropsFile = createPropertiesFile(MessagingType.FAKE, false, false);
-    GpactCrosschainWrite.main(
-        new String[] {GpactCrossControlManagerGroup.GpactVersion.V1.toString(), tempPropsFile});
-  }
 }

--- a/examples/helpers/src/main/java/net/consensys/gpact/helpers/BaseExampleSystemManager.java
+++ b/examples/helpers/src/main/java/net/consensys/gpact/helpers/BaseExampleSystemManager.java
@@ -241,9 +241,9 @@ public abstract class BaseExampleSystemManager {
 
   protected abstract void loadFunctionLayerProperties(PropertiesLoader propsLoader);
 
-  protected abstract CrossControlManagerGroup getFunctionCallInstance() throws Exception;
+  public abstract CrossControlManagerGroup getFunctionCallInstance() throws Exception;
 
-  protected abstract String getFunctionCallImplName() throws Exception;
+  public abstract String getFunctionCallImplName() throws Exception;
 
   private void setupCrosschainTrust(
       CrossControlManagerGroup crossControlManagerGroup,

--- a/examples/helpers/src/main/java/net/consensys/gpact/helpers/GpactExampleSystemManager.java
+++ b/examples/helpers/src/main/java/net/consensys/gpact/helpers/GpactExampleSystemManager.java
@@ -16,6 +16,7 @@ package net.consensys.gpact.helpers;
 
 import net.consensys.gpact.CrosschainProtocols;
 import net.consensys.gpact.common.StatsHolder;
+import net.consensys.gpact.functioncall.gpact.GpactCrossControlManagerGroup;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -47,4 +48,6 @@ public abstract class GpactExampleSystemManager extends BaseExampleSystemManager
   public ExecutionEngineType getExecutionEngineType() {
     return executionEngineType;
   }
+
+  public abstract GpactCrossControlManagerGroup.GpactVersion getGpactVersion();
 }

--- a/examples/helpers/src/main/java/net/consensys/gpact/helpers/GpactV1ExampleSystemManager.java
+++ b/examples/helpers/src/main/java/net/consensys/gpact/helpers/GpactV1ExampleSystemManager.java
@@ -16,6 +16,7 @@ package net.consensys.gpact.helpers;
 
 import net.consensys.gpact.CrosschainProtocols;
 import net.consensys.gpact.functioncall.CrossControlManagerGroup;
+import net.consensys.gpact.functioncall.gpact.GpactCrossControlManagerGroup;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -26,11 +27,15 @@ public class GpactV1ExampleSystemManager extends GpactExampleSystemManager {
     super(propertiesFileName);
   }
 
-  protected CrossControlManagerGroup getFunctionCallInstance() throws Exception {
+  public CrossControlManagerGroup getFunctionCallInstance() throws Exception {
     return CrosschainProtocols.getFunctionCallInstance(CrosschainProtocols.GPACT_V1).get();
   }
 
-  protected String getFunctionCallImplName() throws Exception {
+  public String getFunctionCallImplName() throws Exception {
     return CrosschainProtocols.GPACT_V1;
+  }
+
+  public GpactCrossControlManagerGroup.GpactVersion getGpactVersion() {
+    return GpactCrossControlManagerGroup.GpactVersion.V1;
   }
 }

--- a/examples/helpers/src/main/java/net/consensys/gpact/helpers/GpactV2ExampleSystemManager.java
+++ b/examples/helpers/src/main/java/net/consensys/gpact/helpers/GpactV2ExampleSystemManager.java
@@ -16,6 +16,7 @@ package net.consensys.gpact.helpers;
 
 import net.consensys.gpact.CrosschainProtocols;
 import net.consensys.gpact.functioncall.CrossControlManagerGroup;
+import net.consensys.gpact.functioncall.gpact.GpactCrossControlManagerGroup;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -26,11 +27,15 @@ public class GpactV2ExampleSystemManager extends GpactExampleSystemManager {
     super(propertiesFileName);
   }
 
-  protected CrossControlManagerGroup getFunctionCallInstance() throws Exception {
+  public CrossControlManagerGroup getFunctionCallInstance() throws Exception {
     return CrosschainProtocols.getFunctionCallInstance(CrosschainProtocols.GPACT_V2).get();
   }
 
-  protected String getFunctionCallImplName() throws Exception {
+  public String getFunctionCallImplName() throws Exception {
     return CrosschainProtocols.GPACT_V2;
+  }
+
+  public GpactCrossControlManagerGroup.GpactVersion getGpactVersion() {
+    return GpactCrossControlManagerGroup.GpactVersion.V2;
   }
 }

--- a/examples/helpers/src/main/java/net/consensys/gpact/helpers/SfcExampleSystemManager.java
+++ b/examples/helpers/src/main/java/net/consensys/gpact/helpers/SfcExampleSystemManager.java
@@ -28,11 +28,11 @@ public class SfcExampleSystemManager extends BaseExampleSystemManager {
 
   protected void loadFunctionLayerProperties(PropertiesLoader propsLoader) {}
 
-  protected CrossControlManagerGroup getFunctionCallInstance() throws Exception {
+  public CrossControlManagerGroup getFunctionCallInstance() throws Exception {
     return CrosschainProtocols.getFunctionCallInstance(CrosschainProtocols.SFC).get();
   }
 
-  protected String getFunctionCallImplName() throws Exception {
+  public String getFunctionCallImplName() throws Exception {
     return CrosschainProtocols.SFC;
   }
 


### PR DESCRIPTION
Add a test for each GPACT example using the FAKE messaging provider and GPACT v2. For some examples, additionally, ensure when a Crosschain Control engine is created for each user, ensure the correct GPACT version is used.

NOTE: Some tests have been Disabled as they fail at the moment, as crosschain application authentication has not been implemented yet.