### PR TITLE
Crosschain Application Authentication

### DIFF
--- a/contracts/contracts/src/functioncall/common/CallPath.sol
+++ b/contracts/contracts/src/functioncall/common/CallPath.sol
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 ConsenSys Software Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+pragma solidity >=0.8;
+
+contract CallPath {
+    /**
+     * Determine call path of parent. NOTE: Do not call if this current call path represents the root.
+     *
+     * @param _callPath Currently executing call path
+     * @return Call path of parent.
+     */
+    function determineParentCallPath(uint256[] memory _callPath)
+        internal
+        pure
+        returns (uint256[] memory)
+    {
+        uint256[] memory callPathOfParent;
+        uint256 callPathLen = _callPath.length;
+
+        // Don't call from root function
+        //assert(!(callPathLen == 1 && _callPath[0] == 0));
+
+        if (_callPath[callPathLen - 1] != 0) {
+            callPathOfParent = new uint256[](callPathLen);
+            for (uint256 i = 0; i < callPathLen - 1; i++) {
+                callPathOfParent[i] = _callPath[i];
+            }
+            callPathOfParent[callPathLen - 1] = 0;
+        } else {
+            callPathOfParent = new uint256[](callPathLen - 1);
+            for (uint256 i = 0; i < callPathLen - 2; i++) {
+                callPathOfParent[i] = _callPath[i];
+            }
+            callPathOfParent[callPathLen - 2] = 0;
+        }
+        return callPathOfParent;
+    }
+}

--- a/contracts/contracts/src/functioncall/gpact/CallExecutionTreeV1.sol
+++ b/contracts/contracts/src/functioncall/gpact/CallExecutionTreeV1.sol
@@ -16,7 +16,7 @@ pragma solidity >=0.8;
 
 import "../../common/BytesUtil.sol";
 
-contract CallPathCallExecutionTreeV1 is BytesUtil {
+contract CallExecutionTreeV1 is BytesUtil {
     // Offset of the encoding version field in the call tree.
     uint256 private constant OFFSET_OF_TYPE = 0;
     // V1 format.
@@ -120,38 +120,5 @@ contract CallPathCallExecutionTreeV1 is BytesUtil {
         } else {
             functionCall = "";
         }
-    }
-
-    /**
-     * Determine call path of parent. NOTE: Do not call if this current call path represents the root.
-     *
-     * @param _callPath Currently executing call path
-     * @return Call path of parent.
-     */
-    function determineParentCallPath(uint256[] memory _callPath)
-        internal
-        pure
-        returns (uint256[] memory)
-    {
-        uint256[] memory callPathOfParent;
-        uint256 callPathLen = _callPath.length;
-
-        // Don't call from root function
-        //assert(!(callPathLen == 1 && _callPath[0] == 0));
-
-        if (_callPath[callPathLen - 1] != 0) {
-            callPathOfParent = new uint256[](callPathLen);
-            for (uint256 i = 0; i < callPathLen - 1; i++) {
-                callPathOfParent[i] = _callPath[i];
-            }
-            callPathOfParent[callPathLen - 1] = 0;
-        } else {
-            callPathOfParent = new uint256[](callPathLen - 1);
-            for (uint256 i = 0; i < callPathLen - 2; i++) {
-                callPathOfParent[i] = _callPath[i];
-            }
-            callPathOfParent[callPathLen - 2] = 0;
-        }
-        return callPathOfParent;
     }
 }

--- a/contracts/contracts/src/functioncall/gpact/CallExecutionTreeV1Test.sol
+++ b/contracts/contracts/src/functioncall/gpact/CallExecutionTreeV1Test.sol
@@ -14,9 +14,9 @@
  */
 pragma solidity >=0.8;
 
-import "./CallPathCallExecutionTreeV1.sol";
+import "./CallExecutionTreeV1.sol";
 
-contract CallExecutionTreeV1Test is CallPathCallExecutionTreeV1 {
+contract CallExecutionTreeV1Test is CallExecutionTreeV1 {
     function extractTargetFromCallGraph1(
         bytes memory _callGraph,
         uint256[] memory _callPath

--- a/contracts/contracts/src/functioncall/gpact/GpactCrosschainControl.sol
+++ b/contracts/contracts/src/functioncall/gpact/GpactCrosschainControl.sol
@@ -16,17 +16,19 @@ pragma solidity >=0.7.1;
 pragma experimental ABIEncoderV2;
 
 import "../common/CbcDecVer.sol";
-import "./CallPathCallExecutionTreeV1.sol";
+import "./CallExecutionTreeV1.sol";
 import "../interface/LockableStorageInterface.sol";
 import "../interface/CrosschainLockingInterface.sol";
 import "../interface/CrosschainFunctionCallReturnInterface.sol";
 import "../interface/AtomicHiddenAuthParameters.sol";
 import "../../common/ResponseProcessUtil.sol";
+import "../common/CallPath.sol";
 
 contract GpactCrosschainControl is
     CrosschainFunctionCallReturnInterface,
     CbcDecVer,
-    CallPathCallExecutionTreeV1,
+    CallExecutionTreeV1,
+    CallPath,
     CrosschainLockingInterface,
     AtomicHiddenAuthParameters,
     ResponseProcessUtil

--- a/contracts/contracts/src/functioncall/gpactv2/CallExecutionTreeV2.sol
+++ b/contracts/contracts/src/functioncall/gpactv2/CallExecutionTreeV2.sol
@@ -21,7 +21,7 @@ import "../../common/BytesUtil.sol";
  *
  * See ../../../../../docs/call-tree-encoding.md for details of the call tree encoding formats.
  */
-contract CallPathCallExecutionTreeV2 is BytesUtil {
+contract CallExecutionTreeV2 is BytesUtil {
     // Call execution tree type related values.
     // Offset of the type field in the call tree.
     uint256 private constant OFFSET_OF_TYPE = 0;

--- a/contracts/contracts/src/functioncall/gpactv2/CallExecutionTreeV2Test.sol
+++ b/contracts/contracts/src/functioncall/gpactv2/CallExecutionTreeV2Test.sol
@@ -14,9 +14,9 @@
  */
 pragma solidity >=0.8;
 
-import "./CallPathCallExecutionTreeV2.sol";
+import "./CallExecutionTreeV2.sol";
 
-contract CallExecutionTreeV2Test is CallPathCallExecutionTreeV2 {
+contract CallExecutionTreeV2Test is CallExecutionTreeV2 {
     function extractTargetHashFromCallGraph1(
         bytes calldata _callTree,
         uint256[] memory _callPath

--- a/contracts/contracts/src/functioncall/gpactv2/GpactV2CrosschainControl.sol
+++ b/contracts/contracts/src/functioncall/gpactv2/GpactV2CrosschainControl.sol
@@ -222,17 +222,9 @@ contract GpactV2CrosschainControl is
                 _callExecutionTree,
                 _callPath
             );
+            bytes32 functionHash = keccak256(_targetFunctionCallData);
             bytes32 calcTargetHash = keccak256(
-                abi.encodePacked(
-                    myBlockchainId,
-                    _targetContract,
-                    _targetFunctionCallData
-                )
-            );
-            bytes memory val = abi.encodePacked(
-                myBlockchainId,
-                _targetContract,
-                _targetFunctionCallData
+                abi.encodePacked(myBlockchainId, _targetContract, functionHash)
             );
 
             require(
@@ -399,12 +391,9 @@ contract GpactV2CrosschainControl is
                 _callExecutionTree,
                 callPathForRoot
             );
+            bytes32 functionHash = keccak256(_targetFunctionCallData);
             bytes32 calcTargetHash = keccak256(
-                abi.encodePacked(
-                    myBlockchainId,
-                    _targetContract,
-                    _targetFunctionCallData
-                )
+                abi.encodePacked(myBlockchainId, _targetContract, functionHash)
             );
             require(
                 expectedTargetHash == calcTargetHash,
@@ -609,8 +598,9 @@ contract GpactV2CrosschainControl is
             _callTree,
             _callPath
         );
+        bytes32 functionHash = keccak256(_targetCallData);
         bytes32 actualFunctionCallHash = keccak256(
-            abi.encodePacked(myBlockchainId, _targetContract, _targetCallData)
+            abi.encodePacked(myBlockchainId, _targetContract, functionHash)
         );
         require(
             expectedFunctionCallHash == actualFunctionCallHash,
@@ -742,8 +732,10 @@ contract GpactV2CrosschainControl is
             return (true, bytes(""));
         }
 
+        bytes32 calledFuncCallHash = keccak256(_functionCallData);
+
         bytes32 calledFunctionCallHash = keccak256(
-            abi.encodePacked(_blockchainId, _contract, _functionCallData)
+            abi.encodePacked(_blockchainId, _contract, calledFuncCallHash)
         );
 
         bytes32 targetFunctionCallHash = activeCallTargetFunctionCallHashes[

--- a/contracts/contracts/src/functioncall/gpactv2/GpactV2CrosschainControl.sol
+++ b/contracts/contracts/src/functioncall/gpactv2/GpactV2CrosschainControl.sol
@@ -196,6 +196,7 @@ contract GpactV2CrosschainControl is
         Called calldata _target,
         Caller calldata _caller
     ) external {
+        require(_callPath.length > 0, "Call path length too short");
         uint256[] memory callPathMem = _callPath;
 
         decodeAndVerifyEvents(_events, true);

--- a/contracts/contracts/src/functioncall/gpactv2/GpactV2CrosschainControl.sol
+++ b/contracts/contracts/src/functioncall/gpactv2/GpactV2CrosschainControl.sol
@@ -170,10 +170,10 @@ contract GpactV2CrosschainControl is
      * Execute a segment of the call execution tree.
      *
      * @param _events Array of events. Array offset 0 must be the start event. Other events must be segment events.
-     * @ param _callPath    The part of the call tree to be executed.
-     * @ param _callExecutionTree The call tree to be executed. The message digest of this must match the call tree hash emitted in the start event.
-     * @ param _targetContract The contract to be called. A combination of this blockchain, the tartget contract and the target function call data must match the function call hash in the call tree at the call path.
-     * @ param _targetFunctionCallData The call data to be called. A combination of this blockchain, the tartget contract and the target function call data must match the function call hash in the call tree at the call path.
+     * @param _callPath    The part of the call tree to be executed.
+     * @param _callExecutionTree The call tree to be executed. The message digest of this must match the call tree hash emitted in the start event.
+     * @param _targetContract The contract to be called. A combination of this blockchain, the tartget contract and the target function call data must match the function call hash in the call tree at the call path.
+     * @param _targetFunctionCallData The call data to be called. A combination of this blockchain, the tartget contract and the target function call data must match the function call hash in the call tree at the call path.
      */
     function segment(
         // TODO historically, Web3J didn't support arrays of structs in the Java code generator.
@@ -212,24 +212,6 @@ contract GpactV2CrosschainControl is
             require(
                 calcCallExecutionTreeHash == callExecutionTreeHash,
                 "Call execution tree doesn't match start event"
-            );
-        }
-
-        // Check that the the hash of the function call indicated by the call path matches.
-        {
-            // Scope to limit number of local variables compiler has to deal with.
-            bytes32 expectedTargetHash = extractTargetHashFromCallGraph(
-                _callExecutionTree,
-                _callPath
-            );
-            bytes32 functionHash = keccak256(_targetFunctionCallData);
-            bytes32 calcTargetHash = keccak256(
-                abi.encodePacked(myBlockchainId, _targetContract, functionHash)
-            );
-
-            require(
-                expectedTargetHash == calcTargetHash,
-                "Function call does not match call execution tree"
             );
         }
 
@@ -383,23 +365,6 @@ contract GpactV2CrosschainControl is
 
         // The element will be the default, 0.
         uint256[] memory callPathForRoot = new uint256[](1);
-
-        // Check that the the hash of the function call indicated by the call path matches.
-        {
-            // Scope to limit number of local variables compiler has to deal with.
-            bytes32 expectedTargetHash = extractTargetHashFromCallGraph(
-                _callExecutionTree,
-                callPathForRoot
-            );
-            bytes32 functionHash = keccak256(_targetFunctionCallData);
-            bytes32 calcTargetHash = keccak256(
-                abi.encodePacked(myBlockchainId, _targetContract, functionHash)
-            );
-            require(
-                expectedTargetHash == calcTargetHash,
-                "Function call does not match call execution tree"
-            );
-        }
 
         if (
             verifySegmentEvents(
@@ -594,6 +559,7 @@ contract GpactV2CrosschainControl is
         address _targetContract,
         bytes calldata _targetCallData
     ) private returns (bool, bytes memory) {
+        // Check that the the hash of the function call indicated by the call path matches.
         bytes32 expectedFunctionCallHash = extractTargetHashFromCallGraph(
             _callTree,
             _callPath
@@ -733,7 +699,6 @@ contract GpactV2CrosschainControl is
         }
 
         bytes32 calledFuncCallHash = keccak256(_functionCallData);
-
         bytes32 calledFunctionCallHash = keccak256(
             abi.encodePacked(_blockchainId, _contract, calledFuncCallHash)
         );
@@ -756,6 +721,7 @@ contract GpactV2CrosschainControl is
         }
         bytes memory retVal = activeCallReturnValues[returnValuesIndex++];
         activeCallReturnValuesIndex = returnValuesIndex;
+        // TODO CallResult events are not needed and cost gas.
         emit CallResult(_blockchainId, _contract, _functionCallData, retVal);
         return (false, retVal);
     }

--- a/examples/gpact/conditional/java/src/intTest/java/net/consensys/gpact/examples/gpact/conditional/ConditionalTest.java
+++ b/examples/gpact/conditional/java/src/intTest/java/net/consensys/gpact/examples/gpact/conditional/ConditionalTest.java
@@ -11,7 +11,7 @@ public class ConditionalTest extends AbstractExampleTest {
   @Test
   public void directSignSerialSingleBlockchain() throws Exception {
     String tempPropsFile = createPropertiesFile(true, true, true);
-    Main.main(
+    ConditionalExample.main(
         new String[] {GpactCrossControlManagerGroup.GpactVersion.V1.toString(), tempPropsFile});
   }
 
@@ -19,14 +19,14 @@ public class ConditionalTest extends AbstractExampleTest {
   @Test
   public void transferSerialSingleBlockchain() throws Exception {
     String tempPropsFile = createPropertiesFile(false, true, true);
-    Main.main(
+    ConditionalExample.main(
         new String[] {GpactCrossControlManagerGroup.GpactVersion.V1.toString(), tempPropsFile});
   }
 
   @Test
   public void directSignSerialMultiBlockchain() throws Exception {
     String tempPropsFile = createPropertiesFile(true, true, false);
-    Main.main(
+    ConditionalExample.main(
         new String[] {GpactCrossControlManagerGroup.GpactVersion.V1.toString(), tempPropsFile});
   }
 
@@ -34,14 +34,14 @@ public class ConditionalTest extends AbstractExampleTest {
   @Test
   public void transferSerialMultiBlockchain() throws Exception {
     String tempPropsFile = createPropertiesFile(false, true, false);
-    Main.main(
+    ConditionalExample.main(
         new String[] {GpactCrossControlManagerGroup.GpactVersion.V1.toString(), tempPropsFile});
   }
 
   @Test
   public void fakeMessagingSerialMultiBlockchainGpactV2() throws Exception {
     String tempPropsFile = createPropertiesFile(MessagingType.FAKE, true, false);
-    Main.main(
+    ConditionalExample.main(
         new String[] {GpactCrossControlManagerGroup.GpactVersion.V2.toString(), tempPropsFile});
   }
 }

--- a/examples/gpact/conditional/java/src/main/java/net/consensys/gpact/examples/gpact/conditional/ConditionalExample.java
+++ b/examples/gpact/conditional/java/src/main/java/net/consensys/gpact/examples/gpact/conditional/ConditionalExample.java
@@ -27,8 +27,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.web3j.crypto.Credentials;
 
-public class Main extends GpactExampleBase {
-  static final Logger LOG = LogManager.getLogger(Main.class);
+public class ConditionalExample extends GpactExampleBase {
+  static final Logger LOG = LogManager.getLogger(ConditionalExample.class);
 
   public static void main(String[] args) throws Exception {
     StatsHolder.log("Example: Conditional Logic");
@@ -155,5 +155,9 @@ public class Main extends GpactExampleBase {
 
     StatsHolder.log("End");
     StatsHolder.print();
+
+    if (!result.isSuccessful()) {
+      throw new Exception("Crosschain call failed");
+    }
   }
 }

--- a/examples/gpact/erc20bridge/java/src/intTest/java/net/consensys/gpact/examples/gpact/erc20bridge/Erc20BridgeTest.java
+++ b/examples/gpact/erc20bridge/java/src/intTest/java/net/consensys/gpact/examples/gpact/erc20bridge/Erc20BridgeTest.java
@@ -16,7 +16,6 @@ package net.consensys.gpact.examples.gpact.erc20bridge;
 
 import net.consensys.gpact.functioncall.gpact.GpactCrossControlManagerGroup;
 import net.consensys.gpact.helpers.AbstractExampleTest;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class Erc20BridgeTest extends AbstractExampleTest {
@@ -35,8 +34,6 @@ public class Erc20BridgeTest extends AbstractExampleTest {
         new String[] {GpactCrossControlManagerGroup.GpactVersion.V1.toString(), tempPropsFile});
   }
 
-  // TODO: Skip until crosschain application authentication is working
-  @Disabled
   @Test
   public void fakeMessagingSerialMultiBlockchainGpactV2() throws Exception {
     String tempPropsFile = createPropertiesFile(MessagingType.FAKE, true, false);

--- a/examples/gpact/erc20bridge/java/src/main/java/net/consensys/gpact/examples/gpact/erc20bridge/ERC20TokenBridgeExample.java
+++ b/examples/gpact/erc20bridge/java/src/main/java/net/consensys/gpact/examples/gpact/erc20bridge/ERC20TokenBridgeExample.java
@@ -138,20 +138,22 @@ public class ERC20TokenBridgeExample extends GpactExampleBase {
     chainA.showErc20Balances(users);
     chainB.showErc20Balances(users);
 
-    for (int numExecutions = 0; numExecutions < NUM_TIMES_EXECUTE; numExecutions++) {
-      LOG.info("Execution: {}  *****************", numExecutions);
-      StatsHolder.log("Execution: " + numExecutions + " **************************");
+    try {
+      for (int numExecutions = 0; numExecutions < NUM_TIMES_EXECUTE; numExecutions++) {
+        LOG.info("Execution: {}  *****************", numExecutions);
+        StatsHolder.log("Execution: " + numExecutions + " **************************");
 
-      user1.transfer(true, numExecutions + 7);
+        user1.transfer(true, numExecutions + 7);
 
-      chainA.showErc20Balances(users);
-      chainB.showErc20Balances(users);
+        chainA.showErc20Balances(users);
+        chainB.showErc20Balances(users);
+      }
+    } finally {
+      chainA.shutdown();
+      chainB.shutdown();
+
+      StatsHolder.log("End");
+      StatsHolder.print();
     }
-
-    chainA.shutdown();
-    chainB.shutdown();
-
-    StatsHolder.log("End");
-    StatsHolder.print();
   }
 }

--- a/examples/gpact/hotel-train/java/src/intTest/java/net/consensys/gpact/examples/gpact/hoteltrain/HotelTrainTest.java
+++ b/examples/gpact/hotel-train/java/src/intTest/java/net/consensys/gpact/examples/gpact/hoteltrain/HotelTrainTest.java
@@ -2,7 +2,6 @@ package net.consensys.gpact.examples.gpact.hoteltrain;
 
 import net.consensys.gpact.functioncall.gpact.GpactCrossControlManagerGroup;
 import net.consensys.gpact.helpers.AbstractExampleTest;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class HotelTrainTest extends AbstractExampleTest {
@@ -34,8 +33,6 @@ public class HotelTrainTest extends AbstractExampleTest {
         new String[] {GpactCrossControlManagerGroup.GpactVersion.V1.toString(), tempPropsFile});
   }
 
-  // TODO requires crosschain authentication to work
-  @Disabled
   @Test
   public void fakeMessagingParallelMultiBlockchainGpactV2() throws Exception {
     String tempPropsFile = createPropertiesFile(MessagingType.FAKE, false, false);

--- a/examples/gpact/hotel-train/java/src/intTest/java/net/consensys/gpact/examples/gpact/hoteltrain/HotelTrainTest.java
+++ b/examples/gpact/hotel-train/java/src/intTest/java/net/consensys/gpact/examples/gpact/hoteltrain/HotelTrainTest.java
@@ -16,21 +16,21 @@ public class HotelTrainTest extends AbstractExampleTest {
   @Test
   public void directSignSerialMultiBlockchain() throws Exception {
     String tempPropsFile = createPropertiesFile(true, true, false);
-    HotelTrain.main(
+    HotelTrainExample.main(
         new String[] {GpactCrossControlManagerGroup.GpactVersion.V1.toString(), tempPropsFile});
   }
 
   @Test
   public void transferSerialMultiBlockchain() throws Exception {
     String tempPropsFile = createPropertiesFile(false, true, false);
-    HotelTrain.main(
+    HotelTrainExample.main(
         new String[] {GpactCrossControlManagerGroup.GpactVersion.V1.toString(), tempPropsFile});
   }
 
   @Test
   public void directParallelMultiBlockchain() throws Exception {
     String tempPropsFile = createPropertiesFile(true, false, false);
-    HotelTrain.main(
+    HotelTrainExample.main(
         new String[] {GpactCrossControlManagerGroup.GpactVersion.V1.toString(), tempPropsFile});
   }
 
@@ -39,7 +39,7 @@ public class HotelTrainTest extends AbstractExampleTest {
   @Test
   public void fakeMessagingParallelMultiBlockchainGpactV2() throws Exception {
     String tempPropsFile = createPropertiesFile(MessagingType.FAKE, false, false);
-    HotelTrain.main(
+    HotelTrainExample.main(
         new String[] {GpactCrossControlManagerGroup.GpactVersion.V2.toString(), tempPropsFile});
   }
 }

--- a/examples/gpact/hotel-train/java/src/main/java/net/consensys/gpact/examples/gpact/hoteltrain/HotelTrainExample.java
+++ b/examples/gpact/hotel-train/java/src/main/java/net/consensys/gpact/examples/gpact/hoteltrain/HotelTrainExample.java
@@ -27,8 +27,8 @@ import org.apache.logging.log4j.Logger;
  *
  * <p>Book a hotel room and a train seat atomically.
  */
-public class HotelTrain extends GpactExampleBase {
-  private static final Logger LOG = LogManager.getLogger(HotelTrain.class);
+public class HotelTrainExample extends GpactExampleBase {
+  private static final Logger LOG = LogManager.getLogger(HotelTrainExample.class);
 
   static int NUM_TIMES_EXECUTE = 1;
 
@@ -107,52 +107,54 @@ public class HotelTrain extends GpactExampleBase {
     train.showErc20Allowance(
         travelAgency.getTravelAgencyAccount(), train.getTrainContractAddress());
 
-    for (int numExecutions = 0; numExecutions <= NUM_TIMES_EXECUTE; numExecutions++) {
-      LOG.info("Execution: {}  *****************", numExecutions);
-      StatsHolder.log("Execution: " + numExecutions + " **************************");
+    try {
+      for (int numExecutions = 0; numExecutions <= NUM_TIMES_EXECUTE; numExecutions++) {
+        LOG.info("Execution: {}  *****************", numExecutions);
+        StatsHolder.log("Execution: " + numExecutions + " **************************");
 
-      BigInteger bookingId = travelAgency.book(date, exampleManager);
+        BigInteger bookingId = travelAgency.book(date, exampleManager);
 
-      hotel.showBookingInformation(bookingId);
-      train.showBookingInformation(bookingId);
-      hotel.showErc20Balances(accounts);
-      train.showErc20Balances(accounts);
-      hotel.showErc20Allowance(
-          travelAgency.getTravelAgencyAccount(), hotel.getHotelContractAddress());
-      train.showErc20Allowance(
-          travelAgency.getTravelAgencyAccount(), train.getTrainContractAddress());
+        hotel.showBookingInformation(bookingId);
+        train.showBookingInformation(bookingId);
+        hotel.showErc20Balances(accounts);
+        train.showErc20Balances(accounts);
+        hotel.showErc20Allowance(
+            travelAgency.getTravelAgencyAccount(), hotel.getHotelContractAddress());
+        train.showErc20Allowance(
+            travelAgency.getTravelAgencyAccount(), train.getTrainContractAddress());
 
-      travelAgency.book(date, exampleManager);
-      travelAgency.book(date, exampleManager);
-
-      hotel.showErc20Balances(accounts);
-      train.showErc20Balances(accounts);
-      hotel.showErc20Allowance(
-          travelAgency.getTravelAgencyAccount(), hotel.getHotelContractAddress());
-      train.showErc20Allowance(
-          travelAgency.getTravelAgencyAccount(), train.getTrainContractAddress());
-      try {
         travelAgency.book(date, exampleManager);
-        throw new Exception("Exception now thrown as expected");
-      } catch (Exception ex) {
-        LOG.info("Exception thrown as expected: not enough train seats");
+        travelAgency.book(date, exampleManager);
+
+        hotel.showErc20Balances(accounts);
+        train.showErc20Balances(accounts);
+        hotel.showErc20Allowance(
+            travelAgency.getTravelAgencyAccount(), hotel.getHotelContractAddress());
+        train.showErc20Allowance(
+            travelAgency.getTravelAgencyAccount(), train.getTrainContractAddress());
+        try {
+          travelAgency.book(date, exampleManager);
+          throw new Exception("Exception now thrown as expected");
+        } catch (Exception ex) {
+          LOG.info("Exception thrown as expected: not enough train seats");
+        }
+
+        hotel.showErc20Balances(accounts);
+        train.showErc20Balances(accounts);
+        hotel.showErc20Allowance(
+            travelAgency.getTravelAgencyAccount(), hotel.getHotelContractAddress());
+        train.showErc20Allowance(
+            travelAgency.getTravelAgencyAccount(), train.getTrainContractAddress());
+
+        date++;
       }
+    } finally {
+      hotel.shutdown();
+      train.shutdown();
+      travelAgency.shutdown();
 
-      hotel.showErc20Balances(accounts);
-      train.showErc20Balances(accounts);
-      hotel.showErc20Allowance(
-          travelAgency.getTravelAgencyAccount(), hotel.getHotelContractAddress());
-      train.showErc20Allowance(
-          travelAgency.getTravelAgencyAccount(), train.getTrainContractAddress());
-
-      date++;
+      StatsHolder.log("End");
+      StatsHolder.print();
     }
-
-    hotel.shutdown();
-    train.shutdown();
-    travelAgency.shutdown();
-
-    StatsHolder.log("End");
-    StatsHolder.print();
   }
 }

--- a/examples/gpact/read/java/src/intTest/java/net/consensys/gpact/examples/gpact/read/CrosschainRead.java
+++ b/examples/gpact/read/java/src/intTest/java/net/consensys/gpact/examples/gpact/read/CrosschainRead.java
@@ -11,7 +11,7 @@ public class CrosschainRead extends AbstractExampleTest {
   @Test
   public void directSignSerialSingleBlockchain() throws Exception {
     String tempPropsFile = createPropertiesFile(true, true, true);
-    Main.main(
+    ReadExample.main(
         new String[] {GpactCrossControlManagerGroup.GpactVersion.V1.toString(), tempPropsFile});
   }
 
@@ -19,7 +19,7 @@ public class CrosschainRead extends AbstractExampleTest {
   @Test
   public void directSignParallelSingleBlockchain() throws Exception {
     String tempPropsFile = createPropertiesFile(true, false, true);
-    Main.main(
+    ReadExample.main(
         new String[] {GpactCrossControlManagerGroup.GpactVersion.V1.toString(), tempPropsFile});
   }
 
@@ -27,7 +27,7 @@ public class CrosschainRead extends AbstractExampleTest {
   @Test
   public void transferSerialSingleBlockchain() throws Exception {
     String tempPropsFile = createPropertiesFile(false, true, true);
-    Main.main(
+    ReadExample.main(
         new String[] {GpactCrossControlManagerGroup.GpactVersion.V1.toString(), tempPropsFile});
   }
 
@@ -35,14 +35,14 @@ public class CrosschainRead extends AbstractExampleTest {
   @Test
   public void transferParallelSingleBlockchain() throws Exception {
     String tempPropsFile = createPropertiesFile(false, false, true);
-    Main.main(
+    ReadExample.main(
         new String[] {GpactCrossControlManagerGroup.GpactVersion.V1.toString(), tempPropsFile});
   }
 
   @Test
   public void directSignSerialMultiBlockchain() throws Exception {
     String tempPropsFile = createPropertiesFile(true, true, false);
-    Main.main(
+    ReadExample.main(
         new String[] {GpactCrossControlManagerGroup.GpactVersion.V1.toString(), tempPropsFile});
   }
 
@@ -50,14 +50,14 @@ public class CrosschainRead extends AbstractExampleTest {
   @Test
   public void directSignParallelMultiBlockchain() throws Exception {
     String tempPropsFile = createPropertiesFile(true, false, false);
-    Main.main(
+    ReadExample.main(
         new String[] {GpactCrossControlManagerGroup.GpactVersion.V1.toString(), tempPropsFile});
   }
 
   @Test
   public void transferSerialMultiBlockchain() throws Exception {
     String tempPropsFile = createPropertiesFile(false, true, false);
-    Main.main(
+    ReadExample.main(
         new String[] {GpactCrossControlManagerGroup.GpactVersion.V1.toString(), tempPropsFile});
   }
 
@@ -65,14 +65,14 @@ public class CrosschainRead extends AbstractExampleTest {
   @Test
   public void transferParallelMultiBlockchain() throws Exception {
     String tempPropsFile = createPropertiesFile(false, false, false);
-    Main.main(
+    ReadExample.main(
         new String[] {GpactCrossControlManagerGroup.GpactVersion.V1.toString(), tempPropsFile});
   }
 
   @Test
   public void fakeMessagingSerialMultiBlockchainGpactV2() throws Exception {
     String tempPropsFile = createPropertiesFile(MessagingType.FAKE, true, false);
-    Main.main(
+    ReadExample.main(
         new String[] {GpactCrossControlManagerGroup.GpactVersion.V2.toString(), tempPropsFile});
   }
 }

--- a/examples/gpact/trade/java/src/intTest/java/net/consensys/gpact/examples/gpact/trade/TradeTest.java
+++ b/examples/gpact/trade/java/src/intTest/java/net/consensys/gpact/examples/gpact/trade/TradeTest.java
@@ -10,7 +10,7 @@ public class TradeTest extends AbstractExampleTest {
   @Test
   public void directSignSerialSingleBlockchain() throws Exception {
     String tempPropsFile = createPropertiesFile(true, true, true);
-    Main.main(
+    TradeExample.main(
         new String[] {GpactCrossControlManagerGroup.GpactVersion.V1.toString(), tempPropsFile});
   }
 
@@ -19,14 +19,14 @@ public class TradeTest extends AbstractExampleTest {
   @Test
   public void directSignParallelSingleBlockchain() throws Exception {
     String tempPropsFile = createPropertiesFile(true, false, true);
-    Main.main(
+    TradeExample.main(
         new String[] {GpactCrossControlManagerGroup.GpactVersion.V1.toString(), tempPropsFile});
   }
 
   @Test
   public void transferSerialSingleBlockchain() throws Exception {
     String tempPropsFile = createPropertiesFile(false, true, true);
-    Main.main(
+    TradeExample.main(
         new String[] {GpactCrossControlManagerGroup.GpactVersion.V1.toString(), tempPropsFile});
   }
 
@@ -35,7 +35,7 @@ public class TradeTest extends AbstractExampleTest {
   @Test
   public void transferParallelSingleBlockchain() throws Exception {
     String tempPropsFile = createPropertiesFile(false, false, true);
-    Main.main(
+    TradeExample.main(
         new String[] {GpactCrossControlManagerGroup.GpactVersion.V1.toString(), tempPropsFile});
   }
 
@@ -44,7 +44,7 @@ public class TradeTest extends AbstractExampleTest {
   @Test
   public void directSignSerialMultiBlockchain() throws Exception {
     String tempPropsFile = createPropertiesFile(true, true, false);
-    Main.main(
+    TradeExample.main(
         new String[] {GpactCrossControlManagerGroup.GpactVersion.V1.toString(), tempPropsFile});
   }
 
@@ -53,7 +53,7 @@ public class TradeTest extends AbstractExampleTest {
   @Test
   public void directSignParallelMultiBlockchain() throws Exception {
     String tempPropsFile = createPropertiesFile(true, false, false);
-    Main.main(
+    TradeExample.main(
         new String[] {GpactCrossControlManagerGroup.GpactVersion.V1.toString(), tempPropsFile});
   }
 
@@ -62,7 +62,7 @@ public class TradeTest extends AbstractExampleTest {
   @Test
   public void transferSerialMultiBlockchain() throws Exception {
     String tempPropsFile = createPropertiesFile(false, true, false);
-    Main.main(
+    TradeExample.main(
         new String[] {GpactCrossControlManagerGroup.GpactVersion.V1.toString(), tempPropsFile});
   }
 
@@ -71,14 +71,14 @@ public class TradeTest extends AbstractExampleTest {
   @Test
   public void transferParallelMultiBlockchain() throws Exception {
     String tempPropsFile = createPropertiesFile(false, false, false);
-    Main.main(
+    TradeExample.main(
         new String[] {GpactCrossControlManagerGroup.GpactVersion.V1.toString(), tempPropsFile});
   }
 
   @Test
-  public void fakeMessagingParallelMultiBlockchainGpactV2() throws Exception {
-    String tempPropsFile = createPropertiesFile(MessagingType.FAKE, false, false);
-    Main.main(
+  public void fakeMessagingSerialSingleBlockchainGpactV2() throws Exception {
+    String tempPropsFile = createPropertiesFile(MessagingType.FAKE, true, true);
+    TradeExample.main(
         new String[] {GpactCrossControlManagerGroup.GpactVersion.V2.toString(), tempPropsFile});
   }
 }

--- a/examples/gpact/write/java/src/main/java/net/consensys/gpact/examples/gpact/write/Bc2ContractB.java
+++ b/examples/gpact/write/java/src/main/java/net/consensys/gpact/examples/gpact/write/Bc2ContractB.java
@@ -55,13 +55,15 @@ public class Bc2ContractB extends AbstractBlockchain {
     }
   }
 
-  public void showValueWritten() throws Exception {
+  public BigInteger showValueWritten() throws Exception {
     boolean isLocked = this.contractB.isLocked(BigInteger.ZERO).send();
     LOG.info("Contract B's lockable storage: locked: {}", isLocked);
     if (isLocked) {
       throw new RuntimeException(
           "Contract B's lockable storage locked after end of crosschain transaction");
     }
-    LOG.info("ContractB: Value: {}", this.contractB.getVal().send());
+    BigInteger val = this.contractB.getVal().send();
+    LOG.info("ContractB: Value: {}", val);
+    return val;
   }
 }

--- a/examples/gpact/write/java/src/main/java/net/consensys/gpact/examples/gpact/write/GpactCrosschainWrite.java
+++ b/examples/gpact/write/java/src/main/java/net/consensys/gpact/examples/gpact/write/GpactCrosschainWrite.java
@@ -66,11 +66,15 @@ public class GpactCrosschainWrite extends GpactExampleBase {
     SimContractB simContractB = new SimContractB(bc2ContractBBlockchain);
     SimContractA simContractA = new SimContractA(bc1ContractABlockchain, simContractB);
 
+    int value = 7;
+
     for (int numExecutions = 0; numExecutions < NUM_TIMES_EXECUTE; numExecutions++) {
       LOG.info("Execution: {} **************************", numExecutions);
       StatsHolder.log("Execution: " + numExecutions + " **************************");
 
-      BigInteger val = BigInteger.valueOf(7);
+      value += numExecutions;
+
+      BigInteger val = BigInteger.valueOf(value);
 
       simContractA.doCrosschainWrite(val);
 
@@ -95,7 +99,14 @@ public class GpactCrosschainWrite extends GpactExampleBase {
 
       TransactionReceipt txR = result.getTransactionReceipt(CrosschainCallResult.ROOT_CALL);
       bc2ContractBBlockchain.showEvents(txR);
-      bc2ContractBBlockchain.showValueWritten();
+      BigInteger valWritten = bc2ContractBBlockchain.showValueWritten();
+
+      if (!result.isSuccessful()) {
+        throw new Exception("Crosschain call failed");
+      }
+      if (valWritten.intValue() != value) {
+        throw new Exception("Written value not correct");
+      }
     }
 
     bc1ContractABlockchain.shutdown();

--- a/sdk/java/src/main/java/net/consensys/gpact/functioncall/CallExecutionTree.java
+++ b/sdk/java/src/main/java/net/consensys/gpact/functioncall/CallExecutionTree.java
@@ -107,6 +107,10 @@ public class CallExecutionTree {
     return CallExecutionTreeEncoderV2.encodeFunctionCallAndHash(this);
   }
 
+  public byte[] getFunctionDataHash() {
+    return CallExecutionTreeEncoderV2.encodeFunctionDataAndHash(this);
+  }
+
   /**
    * Locate the CallExecutionTree object that matches the call path.
    *

--- a/sdk/java/src/main/java/net/consensys/gpact/functioncall/common/CallExecutionTreeEncoderV2.java
+++ b/sdk/java/src/main/java/net/consensys/gpact/functioncall/common/CallExecutionTreeEncoderV2.java
@@ -156,6 +156,11 @@ public class CallExecutionTreeEncoderV2 extends CallExecutionTreeEncoderBase {
     return keccak256(Bytes.wrap(output)).toArray();
   }
 
+  public static byte[] encodeFunctionDataAndHash(final CallExecutionTree callTree) {
+    byte[] data = callTree.getFunctionCallDataAsBytes();
+    return keccak256(Bytes.wrap(data)).toArray();
+  }
+
   /**
    * Dump an encoded Call Execution Tree.
    *

--- a/sdk/java/src/main/java/net/consensys/gpact/functioncall/common/CallExecutionTreeEncoderV2.java
+++ b/sdk/java/src/main/java/net/consensys/gpact/functioncall/common/CallExecutionTreeEncoderV2.java
@@ -139,8 +139,21 @@ public class CallExecutionTreeEncoderV2 extends CallExecutionTreeEncoderBase {
   }
 
   public static byte[] encodeFunctionCallAndHash(final CallExecutionTree callTree) {
-    byte[] encodedFunction = encodeFunctionCall(callTree);
-    return keccak256(Bytes.wrap(encodedFunction)).toArray();
+    byte[] blockchainIdBytes = callTree.getBlockchainId().asBytes();
+    byte[] address = addressStringToBytes(callTree.getContractAddress());
+    byte[] data = callTree.getFunctionCallDataAsBytes();
+
+    byte[] hashOfFunctionCall = keccak256(Bytes.wrap(data)).toArray();
+
+    ByteBuffer buf = ByteBuffer.allocate(MAX_CALL_EX_TREE_SIZE);
+    buf.put(blockchainIdBytes);
+    buf.put(address);
+    buf.put(hashOfFunctionCall);
+    buf.flip();
+    byte[] output = new byte[buf.limit()];
+    buf.get(output);
+
+    return keccak256(Bytes.wrap(output)).toArray();
   }
 
   /**

--- a/sdk/java/src/main/java/net/consensys/gpact/functioncall/common/CallExecutionTreeEncoderV2.java
+++ b/sdk/java/src/main/java/net/consensys/gpact/functioncall/common/CallExecutionTreeEncoderV2.java
@@ -190,11 +190,11 @@ public class CallExecutionTreeEncoderV2 extends CallExecutionTreeEncoderBase {
     int size = 0;
     switch (encodingType) {
       case ENCODING_FORMAT_V2_SINGLE_LAYER:
-        out.append(" Encoding Format: V2 single-layer");
+        out.append(" Encoding Format: V2 single-layer\n");
         size = processSingleLayer(out, buf);
         break;
       case ENCODING_FORMAT_V2_MULTI_LAYER:
-        out.append(" Encoding Format: V2 multi-layer");
+        out.append(" Encoding Format: V2 multi-layer\n");
         size = processRecursive(out, buf, 0) + 1; // the 1 accounts for the size of the type field
         break;
       default:

--- a/sdk/java/src/main/java/net/consensys/gpact/functioncall/common/CallPath.java
+++ b/sdk/java/src/main/java/net/consensys/gpact/functioncall/common/CallPath.java
@@ -4,6 +4,7 @@ import static net.consensys.gpact.functioncall.CrosschainCallResult.FIRST_CALL;
 import static net.consensys.gpact.functioncall.CrosschainCallResult.ROOT_CALL;
 
 import java.math.BigInteger;
+import java.util.ArrayList;
 import java.util.List;
 
 public class CallPath {
@@ -45,5 +46,18 @@ public class CallPath {
 
   public static BigInteger calculateFirstCallMapKey() {
     return callPathToMapKey(FIRST_CALL);
+  }
+
+  // Don't call from root function
+  public static List<BigInteger> parentCallPath(List<BigInteger> callPath) {
+    List<BigInteger> callPathOfParent = new ArrayList<>(callPath);
+    int lastIndex = callPath.size() - 1;
+    if (callPath.get(lastIndex).compareTo(BigInteger.ZERO) != 0) {
+      callPathOfParent.set(lastIndex, BigInteger.ZERO);
+    } else {
+      callPathOfParent.remove(lastIndex);
+      callPathOfParent.set(lastIndex - 1, BigInteger.ZERO);
+    }
+    return callPathOfParent;
   }
 }


### PR DESCRIPTION
Allow applications to understand the parent blockchain id and contract address. This was achieved by having the caller information supplied to segment. 

To be completed in a separate PR:
* Add a salt to the end of calldata before hashing it. This will make it more difficult for viewers on one chain to determine the call data of a parent, which they would only have in hack form.