### PR TITLE
Remove call result event for GPACTv2

### DIFF
--- a/contracts/contracts/src/functioncall/gpactv2/GpactV2CrosschainControl.sol
+++ b/contracts/contracts/src/functioncall/gpactv2/GpactV2CrosschainControl.sol
@@ -62,12 +62,6 @@ contract GpactV2CrosschainControl is
         address _actualContract,
         bytes _actualFunctionCall
     );
-    event CallResult(
-        uint256 _blockchainId,
-        address _contract,
-        bytes _functionCall,
-        bytes _result
-    );
     event NotEnoughCalls(
         uint256 _expectedNumberOfCalls,
         uint256 _actualNumberOfCalls
@@ -470,10 +464,7 @@ contract GpactV2CrosschainControl is
      *
      * @param _events Array of events. Array offset 0 must be the root event. Other events must be segment events.
      */
-    function signalling(
-        // TODO historically, Web3J didn't support arrays of structs in the Java code generator.
-        EventInfo[] calldata _events
-    ) external {
+    function signalling(EventInfo[] calldata _events) external {
         decodeAndVerifyEvents(_events, false);
 
         // Extract information from the root event.
@@ -756,8 +747,6 @@ contract GpactV2CrosschainControl is
         }
         bytes memory retVal = activeCallReturnValues[returnValuesIndex++];
         activeCallReturnValuesIndex = returnValuesIndex;
-        // TODO CallResult events are not needed and cost gas.
-        emit CallResult(_blockchainId, _contract, _functionCallData, retVal);
         return (false, retVal);
     }
 

--- a/sdk/java/src/main/java/net/consensys/gpact/functioncall/gpact/v2/GpactV2CrossControlManager.java
+++ b/sdk/java/src/main/java/net/consensys/gpact/functioncall/gpact/v2/GpactV2CrossControlManager.java
@@ -207,8 +207,6 @@ public class GpactV2CrossControlManager extends AbstractGpactCrossControlManager
         convertNotEnoughCalls(this.crossBlockchainControlContract.getNotEnoughCallsEvents(txR)));
     showCallFailureEvents(
         convertCallFailure(this.crossBlockchainControlContract.getCallFailureEvents(txR)));
-    showCallResultEvents(
-        convertCallResult(this.crossBlockchainControlContract.getCallResultEvents(txR)));
     showDumpEvents(convertDump(this.crossBlockchainControlContract.getDumpEvents(txR)));
 
     List<net.consensys.gpact.functioncall.gpact.GpactV2CrosschainControl.SegmentEventResponse>
@@ -290,8 +288,6 @@ public class GpactV2CrossControlManager extends AbstractGpactCrossControlManager
         convertNotEnoughCalls(this.crossBlockchainControlContract.getNotEnoughCallsEvents(txR)));
     showCallFailureEvents(
         convertCallFailure(this.crossBlockchainControlContract.getCallFailureEvents(txR)));
-    showCallResultEvents(
-        convertCallResult(this.crossBlockchainControlContract.getCallResultEvents(txR)));
     showDumpEvents(this.convertDump(this.crossBlockchainControlContract.getDumpEvents(txR)));
 
     List<net.consensys.gpact.functioncall.gpact.GpactV2CrosschainControl.RootEventResponse>
@@ -379,19 +375,6 @@ public class GpactV2CrossControlManager extends AbstractGpactCrossControlManager
     for (net.consensys.gpact.functioncall.gpact.GpactV2CrosschainControl.CallFailureEventResponse
         e : callFailureEventResponses) {
       CallFailureEventResponse event = new CallFailureEventResponse(e._revertReason);
-      result.add(event);
-    }
-    return result;
-  }
-
-  private List<CallResultEventResponse> convertCallResult(
-      List<net.consensys.gpact.functioncall.gpact.GpactV2CrosschainControl.CallResultEventResponse>
-          callResultEventResponses) {
-    List<CallResultEventResponse> result = new ArrayList<>();
-    for (net.consensys.gpact.functioncall.gpact.GpactV2CrosschainControl.CallResultEventResponse e :
-        callResultEventResponses) {
-      CallResultEventResponse event =
-          new CallResultEventResponse(e._blockchainId, e._contract, e._functionCall, e._result);
       result.add(event);
     }
     return result;


### PR DESCRIPTION
The Call Result Event shows the result to be returned from a crosschain call to an executing function. This is informational only, and helped with debugging GPACTv1. This costs gas and serves to purpose. As such, this PR removes the Call Result Event, and associated SDK code.